### PR TITLE
new class, FluxCalculation, for setting flux data

### DIFF
--- a/vectgen/GNUmakefile
+++ b/vectgen/GNUmakefile
@@ -26,14 +26,17 @@ OBJS = $(patsubst src/%.cc, obj/%.o, $(SRCS))
 
 CFLAGS += -DNO_EXTERN_COMMON_POINTERS
 
-TARGET = main
+TARGET = main_srn main_snburst
 
 all: $(TARGET)
 
 main: main.o $(OBJS)
 	@LD_RUN_PATH=$(LIBDIR) $(CXX) $(CXXFLAGS) -o $@ main.o $(OBJS) $(LDLIBS)
 
-main.o: main.cc
+main_srn: main_srn.o $(OBJS)
+	@LD_RUN_PATH=$(LIBDIR) $(CXX) $(CXXFLAGS) $(LDLIBS) -o $@ $<
+
+%.o: %.cc
 	@$(CXX) $(CXXFLAGS) -c $< -o $@
 
 obj/%.o: src/%.cc obj

--- a/vectgen/include/FluxCalculation.hh
+++ b/vectgen/include/FluxCalculation.hh
@@ -1,0 +1,46 @@
+// File: FluxCalculation.hh
+// Created  at 10 DEC 2021 by S.IZUMIYAMA
+// Modified at 21 APR 2022 by S.IZUMIYAMA towards merge into SKSNSim
+
+#ifndef _FLUXCALCULATION_HH_INCLUDED_
+#define _FLUXCALCULATION_HH_INCLUDED_
+
+#include <string>
+#include <vector>
+#include <iostream>
+
+// #define RETURNEXCEPATIONS 
+// This enables throwing exceptions to notify some errror (e.g. the specified energy is out of range)
+#ifdef RETURNEXCEPATIONS
+#include <typeinfo>
+#endif
+
+class FluxCalculation {
+  private:
+    std::vector<std::pair<double,double> > *ene_flux_v = NULL; /* size_t -> <energy, flux> */
+    double lower_energy_bin_width;
+    double upper_energy_bin_width;
+    void sortByEnergy();
+
+  public:
+    const static size_t NBIN = 500;
+    FluxCalculation();
+    FluxCalculation(const std::string /*fname*/);
+    ~FluxCalculation();
+    void loadFile(const std::string /*fname*/);
+    double getFlux(const double /* nu energy in MeV */) const;
+    inline double getFluxLimit(const bool lower_limit = true /* if false -> return upper limit*/) const{
+#ifdef RETURNEXCEPATIONS
+      if ( ene_flux_v == NULL ) throw std::bad_typeid("ene_flux_v is not allocated");
+#endif
+      if ( ene_flux_v == NULL ) return -9999;
+      return  lower_limit? ene_flux_v->front().first - lower_energy_bin_width/2.0: ene_flux_v->back().first + upper_energy_bin_width/2.0;
+    }
+    // This throws std::out_of_range when the energy is out of range of loaded flux data
+    void dumpFlux(std::ostream &out = std::cout) const;
+    inline double getBinnedFlux(const int bin) const {return ene_flux_v->at(bin).second;};
+    inline double getBinnedEnergy(const int bin) const {return ene_flux_v->at(bin).first;};
+    inline size_t getNBins() const {return (ene_flux_v != NULL) ? ene_flux_v->size(): 0;};
+};
+
+#endif

--- a/vectgen/include/VectGenGenerator.hh
+++ b/vectgen/include/VectGenGenerator.hh
@@ -17,6 +17,7 @@
 #include <iomanip>
 #include <stdio.h>
 #include <algorithm>
+#include <memory>
 
 #include "snevtinfo.h"
 #include "mcinfo.h"
@@ -28,6 +29,8 @@
 #include "VectGenNuCrosssection.hh"
 
 #include "VectGenSnRoot.hh"
+
+#include "FluxCalculation.hh"
 
 /**
  * @class Generator
@@ -45,8 +48,8 @@ public:
   void determinePosition(double&, double&, double&);
   void FillEvent();
   void MakeEvent(double, double, int, int, double);
-  void Process();
-  void Process(int);
+  void Process();    // For SN generator
+  void Process(int); // For DSBN vector generator
 
 protected:
 
@@ -59,6 +62,7 @@ protected:
 
   VectGenSnFlux* nuflux;
   VectGenNuCrosssection* nucrs;
+  std::unique_ptr<FluxCalculation> nuflux_dsbn;
 
   //Neutrino oscillation
   double oscnue1, oscnue2, oscneb1, oscneb2, oscnux1, oscnux2, oscnxb1, oscnxb2;

--- a/vectgen/include/VectGenIO.hh
+++ b/vectgen/include/VectGenIO.hh
@@ -23,7 +23,7 @@ class VectGenIO : VectGenGenerator
 public:
   VectGenIO(){}
   VectGenIO(std::string, int, double, int, std::string, uint);
-  VectGenIO(std::string, uint);
+  VectGenIO(std::string, uint, std::string); // For DSBN vector generator
   ~VectGenIO(){}
 
   void DoProcess();

--- a/vectgen/main_srn.cc
+++ b/vectgen/main_srn.cc
@@ -1,17 +1,25 @@
 
 #include "VectGenIO.hh"
 
+void ShowUsage(const int argc, char **argv){
+  std::cerr<<" Usage: " << argv[0] << " [options] {} {} {}" << std::endl;
+  std::cerr<<" Argument for "<< argv[0] << std::endl;
+  std::cerr<<" 1st: Number of event" << std::endl;
+  std::cerr<<" 2nd: Output directory, default: ./data/"<< std::endl;
+  std::cerr<<" 3rd: Random seed"<< std::endl;
+  std::cerr<<" Options: -f\n"
+    << "    -f {flux_file_name}: file name of flux data"
+    << std::endl;
+  std::cerr<<" return -1"<<std::endl;
+}
+
 int main( int argc, char ** argv )
 {
 
 	std::cout<<" Start Generating Event "<< argc <<std::endl;
 
 	if(argc < 3){
-	  std::cerr<<" Argument for "<< argv[0] << std::endl;
-	  std::cerr<<" 1st: Number of event" << std::endl;
-	  std::cerr<<" 2nd: Output directory, default: ./data/"<< std::endl;
-	  std::cerr<<" 3rd: Random seed"<< std::endl;
-	  std::cerr<<" return -1"<<std::endl;
+    ShowUsage(argc, argv);
 	  exit(1);
 	}
 
@@ -26,8 +34,14 @@ int main( int argc, char ** argv )
 	uint seedIO = 0;
 	seedIO = atoi(argv[3]);
 
+  /*---- Flux data ----------------*/
+  std::string FluxFile("../expect/horiuchi/8MeV_Nominal.dat");
+	//FluxFile = std::string(argv[4]);
+
+
 	/*-----Geneartion-----*/
-	VectGenIO *io = new VectGenIO(OutDirIO, seedIO);
+
+	VectGenIO *io = new VectGenIO(OutDirIO, seedIO, FluxFile);
 
 	io->DoProcess(NumEv);
 

--- a/vectgen/main_srn.cc
+++ b/vectgen/main_srn.cc
@@ -1,15 +1,21 @@
 
 #include "VectGenIO.hh"
+#include <getopt.h>
 
-void ShowUsage(const int argc, char **argv){
-  std::cerr<<" Usage: " << argv[0] << " [options] {} {} {}" << std::endl;
-  std::cerr<<" Argument for "<< argv[0] << std::endl;
+constexpr double DEFAULT_NUENE_MIN = 5.;
+constexpr double DEFAULT_NUENE_MAX = 100.;
+
+void ShowUsage(char *arg0){
+  std::cerr<< arg0 << " [options] {num_eve} {out_dir} {seed}" << std::endl;
+  std::cerr<< "Usage: vector generetaor for DSBN MC" << std::endl;
+  std::cerr<<" Argument for "<< arg0 << std::endl;
   std::cerr<<" 1st: Number of event" << std::endl;
   std::cerr<<" 2nd: Output directory, default: ./data/"<< std::endl;
   std::cerr<<" 3rd: Random seed"<< std::endl;
-  std::cerr<<" Options: -f\n"
-    << "    -f {flux_file_name}: file name of flux data"
-    << std::endl;
+  std::cerr<<" Options: -f, -h, --flux_file, --nu_ene_{min,max} \n"
+    << "\t-f {flux_data_file}, --flux_file {flux_data_file}: specify flux data file to be used" << std::endl
+    << "\t(not working now) --nu_ene_min {energy_in_MeV}: minimum total energy [MeV] to be generated (default = " << DEFAULT_NUENE_MIN << " MeV)" << std::endl
+    << "\t(not working now) --nu_ene_max {energy_in_MeV}: maximum total energy [MeV] to be generated (default = " << DEFAULT_NUENE_MAX << " MeV)" << std::endl;
   std::cerr<<" return -1"<<std::endl;
 }
 
@@ -18,25 +24,84 @@ int main( int argc, char ** argv )
 
 	std::cout<<" Start Generating Event "<< argc <<std::endl;
 
-	if(argc < 3){
-    ShowUsage(argc, argv);
-	  exit(1);
-	}
+  //=====================
+  // argument controll
+  int c, digit_optind = 0;
+  double nuEne_min = -9999.;
+  double nuEne_max = 9999.;
+  std::string FluxFile ("../expect/horiuchi/8MeV_Nominal.dat");
+  while (1) {
+    int this_option_optind = optind ? optind : 1;
+    int option_index = 0;
+    unsigned long seed_read = 0;
+    enum OPTIONS {kNuEneMin = 0, kNuEneMax, kFluxFile, kHelp};
+    static struct option long_options[] = {
+      {"nu_ene_min",  required_argument, 0, 0},
+      {"nu_ene_max",  required_argument, 0, 0},
+      {"flux_file",   required_argument, 0, 0},
+      {"help",              no_argument, 0, 0},
+      {0,                             0, 0, 0}
+    };
+
+    c = getopt_long( argc, argv, "hf:v",
+        long_options, &option_index);
+    if(c==-1)
+      break;
+
+    switch (c) {
+      case 0:
+        switch(option_index) {
+          case kNuEneMin:
+            nuEne_min = strtod(optarg, NULL);
+            std::cerr << "GETOPT: minumum neutrino energy <- set to = " << nuEne_min << std::endl;
+            break;
+          case kNuEneMax:
+            nuEne_max = strtod(optarg, NULL);
+            std::cerr << "GETOPT: maximum neutrino energy <- set to = " << nuEne_max << std::endl;
+            break;
+          case kFluxFile:
+            FluxFile = std::string(optarg);
+            std::cerr << "GETOPT: flux data file = " << FluxFile << std::endl;
+            break;
+          case kHelp:
+            ShowUsage(argv[0]);
+            return EXIT_SUCCESS;
+            break;
+          default:
+            break;
+        }
+        break;
+      case 'f':
+        FluxFile = std::string(optarg);
+        std::cerr << "GETOPT: flux data file = " << FluxFile << std::endl;
+        break;
+      case 'h':
+        ShowUsage(argv[0]);
+        return EXIT_SUCCESS;
+        break;
+      default:
+        std::cerr << "GETOPT: strange argument: code = " << c << std::endl;
+    }
+  }
+
+  if( optind+3 > argc){
+    ShowUsage(argv[0]);
+    return EXIT_FAILURE;
+  }
 
 	/*-----Number of Generated Event-----*/
-	int NumEv = atoi(argv[1]);
+	int NumEv = atoi(argv[optind]);
 
 	/*-----Output directory-----*/
 	std::string OutDirIO("./data/");
-	OutDirIO = std::string(argv[2]);
+	OutDirIO = std::string(argv[optind +1]);
 
 	/*-----random number initialization-----*/
 	uint seedIO = 0;
-	seedIO = atoi(argv[3]);
+	seedIO = atoi(argv[optind + 2]);
 
   /*---- Flux data ----------------*/
-  std::string FluxFile("../expect/horiuchi/8MeV_Nominal.dat");
-	//FluxFile = std::string(argv[4]);
+  // Already loaded
 
 
 	/*-----Geneartion-----*/

--- a/vectgen/src/FluxCalculation.cc
+++ b/vectgen/src/FluxCalculation.cc
@@ -1,0 +1,97 @@
+// File: FluxCalculation.cc
+// Created  at 10 DEC 2021 by S.IZUMIYAMA
+// Modified at 21 APR 2022 by S.IZUMIYAMA toward merge into SKSNSim
+//
+// Description:
+// Class to load flux data file having data record like csv format
+// -> #Energy flux
+
+#include <vector>
+#include <fstream>
+#include <string>
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <iterator>
+#include "FluxCalculation.hh"
+
+#ifdef RETURNEXCEPATIONS
+#include <stdexcept>
+#endif
+
+FluxCalculation::FluxCalculation(){
+      ene_flux_v = new std::vector<std::pair<double,double> >();
+      lower_energy_bin_width = 0.1;
+      upper_energy_bin_width = 0.1;
+      return;
+}
+FluxCalculation::FluxCalculation(std::string fname){
+      ene_flux_v = new std::vector<std::pair<double,double> >();
+      this->loadFile(fname);
+      return;
+}
+FluxCalculation::~FluxCalculation(){
+  delete ene_flux_v;
+}
+void FluxCalculation::loadFile(const std::string fname){
+  ene_flux_v->clear();
+  std::ifstream datafile(fname.c_str());
+  double ene, flux;
+  for(std::string line; std::getline(datafile, line); ){
+    std::stringstream ss(line);
+    ss >> ene >> flux;
+    ene_flux_v->push_back(std::make_pair(ene, flux));
+  }
+  datafile.close();
+  sortByEnergy();
+  return;
+}
+
+void FluxCalculation::dumpFlux(std::ostream &out) const {
+  for(std::vector<std::pair<double, double> >::iterator it = ene_flux_v->begin(); it != ene_flux_v->end(); it++)
+    out << it->first << " MeV, " << it->second << std::endl;
+}
+
+void FluxCalculation::sortByEnergy(){
+  if(ene_flux_v == NULL) return;
+  // for std::pair, first comparing first-component then comparing second-component
+  std::sort(ene_flux_v->begin(), ene_flux_v->end());
+  if(ene_flux_v->size() > 1){
+    lower_energy_bin_width = (ene_flux_v->begin() + 1)->first - ene_flux_v->begin()->first;
+    upper_energy_bin_width = (ene_flux_v->end()-1)->first - (ene_flux_v->end()-2)->first;
+  }
+  return;
+}
+
+double FluxCalculation::getFlux(const double nu_ene_MeV) const {
+  // Assumed the data field ene_flux_v is sorted as lowest energy on first 
+  // Calculate flux with linear interpolation
+  const static double ERROR_CODE = -9999.;
+  const static double OUTOFRANGE = -9998.;
+  if(ene_flux_v == NULL) return ERROR_CODE;
+  std::pair<double,double> bin = std::make_pair(-1, 0);
+  std::pair<double,double> nextbin;
+  for(std::vector<std::pair<double,double> >::iterator it = ene_flux_v->begin(); it+1 != ene_flux_v->end(); it++){
+    // IMPROVEMENT: if you implement this with binary tree search, it will be faster
+    if(it->first <= nu_ene_MeV && nu_ene_MeV < (it+1)->first){
+      bin = *it;
+      nextbin = *(it+1);
+      break;
+    }
+  }
+  if(bin.first == -1) {
+#ifdef RETURNEXCEPATIONS
+    throw  std::out_of_range("energy is out of range");
+#endif
+    return OUTOFRANGE;
+  }
+
+  double nuFlux = (nextbin.second - bin.second) * (nu_ene_MeV - bin.first) / (nextbin.first - bin.first) + bin.second;
+#ifdef DEBUG
+  std::cout << "FluxCalculation: nuEne = " << nu_ene_MeV <<", flux = " << nuFlux << ", bin = (" << bin.first << ", " << bin.second << ")" << std::endl;
+#endif
+
+  return nuFlux;
+
+}
+

--- a/vectgen/src/VectGenIO.cc
+++ b/vectgen/src/VectGenIO.cc
@@ -126,7 +126,7 @@ VectGenIO::VectGenIO(std::string ModelName, int nuosc, double distIO, int flagIO
 
 }
 
-VectGenIO::VectGenIO(std::string OutDirIO, uint seedIO)
+VectGenIO::VectGenIO(std::string OutDirIO, uint seedIO, std::string FluxFileName)
 {
 	generator = new TRandom3(seedIO);
 	/*
@@ -142,6 +142,7 @@ VectGenIO::VectGenIO(std::string OutDirIO, uint seedIO)
 
 	//Class call of flux/spectrum table
 	//(should be here, but now in VectGenGenerator::Process(int)
+  nuflux_dsbn.reset(new FluxCalculation(FluxFileName));
 
 	//Class call of cross-section calculation
 	nucrs = new VectGenNuCrosssection();


### PR DESCRIPTION
In this request, I divided a part loading flux-data, which loads only Horiuchi-san's model, into new class "FluxCalculation". The usage is just tell the file name of the dat-file and then call "getFlux(...)". The insertion code is copied from GenEvent.cc (original file of this vector generator).

I have checked the build success and the output root file is exactly same in level of ttree information (checked all variables such as energy[0] and compared those of this commit and previous commit).

In addition, I wanted to use some options like "main_srn -f {file} 1000 ./data/ 42". To do that, I implemented getopt function. At this moment, I did not implemented energy limit (--nu_ene_min / --nu_ene_max). It require further modification of VectGenIO or VectGenGenerator (?) class. This is future todo to me.