### PR TITLE
Run by run flux variation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,7 +23,7 @@ FCFLAGS += -w -fPIC -lstdc++
 
 LOCAL_INC	+= -I./include/
 
-LOCAL_LIBS	= -L$(SKOFL_LIBDIR) -lsnlib_1.0 -lsnevtinfo -lsollib_4.0 -lsklowe_7.0 -llibrary 
+LOCAL_LIBS	= -L$(SKOFL_LIBDIR) -lsnlib_1.0 -lsnevtinfo -lsollib_4.0 -lsklowe_7.0 -lwtlib_5.1 -llibrary 
 
 LDFLAGS = $(LOCAL_LIBS) $(LOCAL_INC)
 #INCROOT=-I$(ROOTSYS)/include/
@@ -45,6 +45,7 @@ MAINSRCS += $(wildcard *.F)
 MAINOBJS = $(patsubst %.cc, obj/%.o, $(MAINSRCS))
 MAINBINS = $(patsubst %.cc, bin/%, $(MAINSRCS))
 SKSNSIMLIBOBJS = $(filter obj/SKSNSim%, $(OBJS))
+SKSNSIMLIBOBJS += $(filter obj/elapseday%, $(OBJS))
 
 main: bin obj bin/main_snburst bin/main_dsnb bin/main_snburst_prev bin/main_dsnb_prev bin/main_dsnb_new bin/main_snburst_new
 
@@ -66,7 +67,7 @@ obj/%.o: %.cc
 
 obj/%.o: src/%.cc
 	@echo "[SKSNSim] Building $* ..."
-	$(CXX) $(CXXFLAGS) -c $< -o $@
+	@$(CXX) $(CXXFLAGS) -c $< -o $@
 
 obj/%.o: src/%.F
 	@echo "[SKSNSim] Building FORTRAN code: $*..."
@@ -90,15 +91,15 @@ bin/main_snburst_new: obj/main_snburst_new.o $(OBJS)
 
 bin/main_snburst: bin/main_snburst_prev
 	@${LN} main_snburst_prev $@
-	#@${LN} main_snburst_new $@
+# @${LN} main_snburst_new $@
 
 bin/main_dsnb: bin/main_dsnb_prev
 	@${LN} main_dsnb_prev $@
-	#@${LN} main_dsnb_new $@
+# @${LN} main_dsnb_new $@
 
 lib/libSKSNSim.so: $(SKSNSIMLIBOBJS)
 	@echo "[SKSNSim] Making shared library: $@..."
-	LD_RUN_PATH=$(SKOFL) $(CXX) $(LDFLAGS) $(CXXFLAGS) -shared -o $@ $(SKSNSIMLIBOBJS)  $(LDLIBS) #$(SKOFL_LIBDIR)/libsollib_4.0.a $(SKOFL_LIBDIR)/libsnlib_1.0.a $(SKOFL_LIBDIR)/libiolib.a
+	@LD_RUN_PATH=$(SKOFL) $(CXX) $(LDFLAGS) $(CXXFLAGS) -shared -o $@ $^ $(LDLIBS)
 
 obj bin lib:
 	@mkdir -p $@

--- a/include/SKSNSimConstant.hh
+++ b/include/SKSNSimConstant.hh
@@ -1,6 +1,9 @@
 /*********************************
  * SKSNSimConstant.hh
  ********************************/
+#ifndef __SKSNSIMCONSTANT_H_INCLUDED__
+#define __SKSNSIMCONSTANT_H_INCLUDED__
+
 #include <cmath>
 #include <map>
 #include "SKSNSimEnum.hh"
@@ -24,6 +27,8 @@ namespace SKSNSimPhysConst {
   constexpr double Ntarget_p = 2.173e33;
   constexpr double Ntarget_e = 1.086e34;
   constexpr double Ntarget_o = 1.086e33;
+
+  constexpr double FVCUT = 200.;
 
   // Unit of the distance to the Supenova 10kpc = 3.086 x 10^22 cm
   constexpr double Distance = 3.086e22; // cm for 10kpc
@@ -54,3 +59,4 @@ namespace SKSNSimPhysConst {
   double GetNuOscNuxb2(SKSNSIMENUM::NEUTRINOOSCILLATION t){return std::get<7>(NuOscProbCollection.at(t));}
 
 }
+#endif

--- a/include/SKSNSimFileIO.hh
+++ b/include/SKSNSimFileIO.hh
@@ -46,6 +46,8 @@ class SKSNSimFileOutTFile : public SKSNSimFileOutput {
     SNEvtInfo *m_SN;
     TTree *m_OutTree;
 
+    Double_t weight;
+    TTree *m_OutWeightTree;
 
   public:
     SKSNSimFileOutTFile (){ m_fileptr = NULL; m_MC = NULL; m_SN = NULL; }

--- a/include/SKSNSimFlux.hh
+++ b/include/SKSNSimFlux.hh
@@ -210,6 +210,7 @@ class SKSNSimDSNBFluxMonthlyCustom : SKSNSimFluxModel {
     /* this return flux which fulfilling "t >= (elem[n]->begin_elapsed_day) && t < (elem[n+1]->begin_elapsed_day)" */
 
     double FindMaxFluxTime() const ;
+    SKSNSimDSNBFluxCustom &FindFluxByTime(const int d /* elapsed day from 1996/01/01 */) const { return findFluxByTime(d);}
 
     double GetEnergyLimitMax() const { if(custommonthlyflux.empty()) return -1.0;
       return custommonthlyflux.front().second->GetEnergyLimitMax(); }

--- a/include/SKSNSimFlux.hh
+++ b/include/SKSNSimFlux.hh
@@ -141,7 +141,6 @@ class SKSNSimSNFluxNakazatoFormat : public SKSNSimBinnedFluxModel {
 class SKSNSimSNFluxNakazato : public SKSNSimBinnedFluxModel {
   private:
     std::unique_ptr<SKSNSimSNFluxCustom> flux;; // TODO modify to changeable file name (model)
-
   public:
     SKSNSimSNFluxNakazato(){
       flux = std::make_unique<SKSNSimSNFluxCustom>( "/home/sklowe/supernova/data/nakazato/intp2002.data" );
@@ -187,6 +186,31 @@ class SKSNSimFluxFlat : SKSNSimFluxModel {
     double GetFlux(const double e, const double t, const FLUXNUTYPE type) const { return 0.0; }
     double GetEnergyLimitMax() const { return 100.0; }
     double GetEnergyLimitMin() const { return 10.0; }
+    const std::set<FLUXNUTYPE> &GetSupportedNuTypes() const { return supportedType; }
+};
+
+class SKSNSimFluxMonthlyCustom : SKSNSimFluxModel {
+  private: 
+    std::vector< std::pair< int /* begin_elapsday */, std::unique_ptr<SKSNSimDSNBFluxCustom> > > custommonthlyflux;
+    void sortByTime ();
+    const std::set<FLUXNUTYPE> supportedType = {FLUXNUEB};
+    SKSNSimDSNBFluxCustom &findFluxByTime(const int /* elapsed day from 1996/01/01 */) const;
+
+  public:
+    SKSNSimFluxMonthlyCustom() {}
+    ~SKSNSimFluxMonthlyCustom() {}
+    void AddMonthlyFlux( const int /* elapse_day from 1996/01/01 */, std::unique_ptr<SKSNSimDSNBFluxCustom> ); /* unique_ptr will be moved to this class */
+    double GetFlux(const double /* MeV */, const double /* elapsed day from 1996/01/01 */, const FLUXNUTYPE ) const;
+    /* this return flux which fulfilling "t >= (elem[n]->begin_elapsed_day) && t < (elem[n+1]->begin_elapsed_day)" */
+
+    double GetEnergyLimitMax() const { if(custommonthlyflux.empty()) return -1.0;
+      return custommonthlyflux.front().second->GetEnergyLimitMax(); }
+    double GetEnergyLimitMin() const { if(custommonthlyflux.empty()) return -1.0;
+      return custommonthlyflux.front().second->GetEnergyLimitMin(); }
+    double GetTimeLimitMax() const { if(custommonthlyflux.empty()) return -1.0;
+      return custommonthlyflux.front().first; }
+    double GetTimeLimitMin() const { if(custommonthlyflux.empty()) return -1.0;
+      return custommonthlyflux.back().first; } // !!Be careful!! THIS IS AN EXCEPTION OF LIMIT VALUE. THIS IS INCLUSIVE.
     const std::set<FLUXNUTYPE> &GetSupportedNuTypes() const { return supportedType; }
 };
 

--- a/include/SKSNSimTools.hh
+++ b/include/SKSNSimTools.hh
@@ -8,7 +8,15 @@
 #include <string>
 #include <map>
 #include "SKSNSimEnum.hh"
+#include "SKSNSimConstant.hh"
+#include <geotnkC.h>
 
+using namespace SKSNSimPhysConst;
+constexpr double VOL[(size_t)SKSNSIMENUM::TANKVOLUME::kNTANKVOLUME] = { 
+  /* kIDFV */ (RINTK-FVCUT)*(RINTK-FVCUT)*PI*(ZPINTK-FVCUT)*2.,
+  /* kIDFULL */ RINTK*RINTK*PI*ZPINTK*2.,
+  /* kTANKFULL */ RTKTK*RTKTK*PI*ZPTKTK*2.
+};
 namespace SKSNSimTools{
   auto DumpDebugMessage = [] (TString str) {
 #ifdef DEBUG
@@ -17,6 +25,18 @@ namespace SKSNSimTools{
   };
 
   SKSNSIMENUM::SKPERIOD FindSKPeriod(int /* run */);
+
+  double GetVolume(SKSNSIMENUM::TANKVOLUME t){
+    return VOL[(size_t)t];
+  }
+  double GetNTargetP(SKSNSIMENUM::TANKVOLUME t){
+    constexpr double NTGT[(size_t)SKSNSIMENUM::TANKVOLUME::kNTANKVOLUME] = {
+      /* kIDFV */      Ntarget_p * VOL[(size_t)SKSNSIMENUM::TANKVOLUME::kIDFV]/VOL[(size_t)SKSNSIMENUM::TANKVOLUME::kIDFULL],
+      /* kIDFULL */    Ntarget_p,
+      /* kTANKFULL */  Ntarget_p * VOL[(size_t)SKSNSIMENUM::TANKVOLUME::kTANKFULL]/VOL[(size_t)SKSNSIMENUM::TANKVOLUME::kIDFULL]
+    };
+    return NTGT[(size_t)t];
+  }
 
   int elapseday(int /* year */, int /* month */, int /* day */);
   int elapseday(int /* run */);

--- a/include/SKSNSimTools.hh
+++ b/include/SKSNSimTools.hh
@@ -17,6 +17,9 @@ namespace SKSNSimTools{
   };
 
   SKSNSIMENUM::SKPERIOD FindSKPeriod(int /* run */);
+
+  int elapseday(int /* year */, int /* month */, int /* day */);
+  int elapseday(int /* run */);
 }
 
 namespace SKSNSimLiveTime {

--- a/include/SKSNSimUserConfiguration.hh
+++ b/include/SKSNSimUserConfiguration.hh
@@ -234,6 +234,10 @@ class SKSNSimUserConfiguration{
 
     void Apply( SKSNSimVectorSNGenerator &gen ) const ;
     void Apply( SKSNSimVectorGenerator   &gen ) const ;
+
+  public:
+    static void ShowHelpDSNB(const char *argv0);
+    static void ShowHelpSN(const char *argv0);
 };
 
 

--- a/include/SKSNSimVectorGenerator.hh
+++ b/include/SKSNSimVectorGenerator.hh
@@ -105,6 +105,7 @@ class SKSNSimSNEventVector {
 
     size_t m_n_randomthrow;
     double m_weight_maxprob;
+    double m_weight;
 
     struct VERTEX {
       double x,y,z; // cm
@@ -139,7 +140,7 @@ class SKSNSimSNEventVector {
 		///static void determineKinematics( SKSNSimSNEventVector &p);
 
   public:
-    SKSNSimSNEventVector() : m_n_randomthrow(0), m_weight_maxprob(0.) {sninfo.iEvt = -1;};
+    SKSNSimSNEventVector() : m_n_randomthrow(0), m_weight_maxprob(0.), m_weight(0.) {sninfo.iEvt = -1;};
     ~SKSNSimSNEventVector() {};
     int AddVertex(
         double x, double y, double z,
@@ -201,6 +202,9 @@ class SKSNSimSNEventVector {
     auto GetWeightMaxProb() const { return m_weight_maxprob; }
     auto SetWeightMaxProb(const double w) { m_weight_maxprob = w; return GetWeightMaxProb(); }
 
+    auto GetWeight() const { return m_weight; }
+    auto SetWeight(const double w) { m_weight= w; return GetWeight(); }
+
     bool operator< (const SKSNSimSNEventVector &a){ return sninfo.rTime < a.sninfo.rTime; }
 };
 
@@ -231,7 +235,7 @@ class SKSNSimVectorGenerator {
 
     // For hit-and-miss method
     double m_max_hit_probability; // maximum of (flux) x (xsec) // should be updated with new flux or xsec models
-    static double FindMaxProb ( SKSNSimFluxModel &, SKSNSimCrosssectionModel &);
+    static double FindMaxProb ( SKSNSimFluxModel &, SKSNSimCrosssectionModel &, int /* elapseday */ = -1);
     double SetMaximumHitProbability();
     
   public:

--- a/src/SKSNSimFileIO.cc
+++ b/src/SKSNSimFileIO.cc
@@ -51,18 +51,22 @@ void SKSNSimFileOutTFile::Open(const std::string fname, const bool including_sne
 
 	// define tree
 	m_OutTree = new TTree("data", "SK 5 tree");
+	m_OutWeightTree = new TTree("weightTr", "Weight");
 	// new MF
 	m_OutTree->SetCacheSize(40*1024*1024);
 	int bufsize = 8*1024*1024;      // may be this is the best 15-OCT-2007 Y.T.
 	m_OutTree->Branch(TopBranch,bufsize);
+  m_OutWeightTree->Branch("weight", &weight, "weight/D");
 }
 
 void SKSNSimFileOutTFile::Close(){
   std::cout << m_fileptr->GetName() << std::endl;
 	m_fileptr->cd();
 	m_OutTree->Write();
+  m_OutWeightTree->Write();
   m_fileptr->Save();
 	m_OutTree->Reset();
+  m_OutWeightTree->Reset();
 	m_fileptr->Close();
 }
 
@@ -112,6 +116,9 @@ void SKSNSimFileOutTFile::Write(const SKSNSimSNEventVector &ev){
   }
 
   m_OutTree->Fill();
+
+  weight = ev.GetWeight();
+  m_OutWeightTree->Fill();
 }
 
 std::vector<SKSNSimFileSet> GenerateOutputFileListNoRuntime(const SKSNSimUserConfiguration &conf){

--- a/src/SKSNSimFlux.cc
+++ b/src/SKSNSimFlux.cc
@@ -25,22 +25,24 @@ SKSNSimDSNBFluxCustom::SKSNSimDSNBFluxCustom()
       return;
 }
 
-SKSNSimDSNBFluxCustom::SKSNSimDSNBFluxCustom(const std::string fname)
+SKSNSimDSNBFluxCustom::SKSNSimDSNBFluxCustom(const std::string fname, const std::string delim)
 {
       std::cout << " DSNB flux file: "<<fname<< std::endl;
       ene_flux_v = std::make_unique<std::vector<std::pair<double,double>>>();
-      this->loadFile(fname);
+      this->loadFile(fname, delim);
       return;
 }
 
-void SKSNSimDSNBFluxCustom::loadFile(const std::string fname)
+void SKSNSimDSNBFluxCustom::loadFile(const std::string fname, const std::string delim)
 {
   ene_flux_v->clear();
   std::ifstream datafile(fname.c_str());
   double ene, flux;
   for(std::string line; std::getline(datafile, line); ){
-    std::stringstream ss(line);
-    ss >> ene >> flux;
+    auto pos_delim = line.find(delim);
+    double ene = std::stod( line.substr(0, pos_delim) );
+    double flux = std::stod( line.substr(pos_delim+1) );
+
     ene_flux_v->push_back(std::make_pair(ene, flux));
   }
   datafile.close();
@@ -96,6 +98,13 @@ double SKSNSimDSNBFluxCustom::GetFlux(const double nu_ene_MeV, const double time
 #endif
 
   return nuFlux;
+}
+
+double SKSNSimDSNBFluxCustom::CalcIntegratedFlux() const {
+  double sum = 0.0;
+  for(size_t b = 0; b < getNBins(); b++)
+    sum += getBinnedFlux(b) * getBinWidth();
+  return sum;
 }
 
 
@@ -224,18 +233,18 @@ double SKSNSimSNFluxCustom::GetFlux(const double e, const double t, const FLUXNU
 
 }
 
-void SKSNSimFluxMonthlyCustom::AddMonthlyFlux( const int elapsday, std::unique_ptr<SKSNSimDSNBFluxCustom> flux_ptr) {
+void SKSNSimDSNBFluxMonthlyCustom::AddMonthlyFlux( const int elapsday, std::unique_ptr<SKSNSimDSNBFluxCustom> flux_ptr) {
   custommonthlyflux.push_back( std::make_pair( elapsday, std::move(flux_ptr) ));
   sortByTime();
 }
 
-void SKSNSimFluxMonthlyCustom::sortByTime() {
+void SKSNSimDSNBFluxMonthlyCustom::sortByTime() {
   std::sort( custommonthlyflux.begin(), custommonthlyflux.end(),
       [](std::pair<int, std::unique_ptr<SKSNSimDSNBFluxCustom>> &a,
         std::pair<int, std::unique_ptr<SKSNSimDSNBFluxCustom>> &b) { return a.first < b.first;});
 }
 
-SKSNSimDSNBFluxCustom &SKSNSimFluxMonthlyCustom::findFluxByTime(const int elapsed_day) const {
+SKSNSimDSNBFluxCustom &SKSNSimDSNBFluxMonthlyCustom::findFluxByTime(const int elapsed_day) const {
   for(auto it = custommonthlyflux.begin(); it != custommonthlyflux.end(); it++){
     if ( elapsed_day < it->first ) continue;
     else {
@@ -246,10 +255,20 @@ SKSNSimDSNBFluxCustom &SKSNSimFluxMonthlyCustom::findFluxByTime(const int elapse
   throw std::out_of_range("elapsed_day is out of range");
 }
 
-double SKSNSimFluxMonthlyCustom::GetFlux(const double e, const double elapsed_day, const FLUXNUTYPE type) const {
+double SKSNSimDSNBFluxMonthlyCustom::GetFlux(const double e, const double elapsed_day, const FLUXNUTYPE type) const {
   try {
     return findFluxByTime(elapsed_day).GetFlux(e,0,type);
   } catch (const std::exception& e){
     return -1.0;
   }
 }
+
+double SKSNSimDSNBFluxMonthlyCustom::FindMaxFluxTime() const {
+  std::vector<std::pair<int, double>> calculated_integrated_flux;
+  for(auto it = custommonthlyflux.begin(); it != custommonthlyflux.end(); it ++)
+    calculated_integrated_flux.push_back(std::make_pair( it->first, it->second->CalcIntegratedFlux()));
+  std::sort ( calculated_integrated_flux.begin(), calculated_integrated_flux.end(), 
+      [](std::pair<int,double> &a, std::pair<int,double>&b){ return a.second < b.second ; });
+  return calculated_integrated_flux.back().first;
+}
+

--- a/src/SKSNSimTools.cc
+++ b/src/SKSNSimTools.cc
@@ -6,6 +6,11 @@
 #include <algorithm>
 #include "SKSNSimTools.hh"
 
+extern "C" {
+  void elapseday_date_(int *, int *, int *, int *);
+  void elapseday_run_(int *, int *);
+}
+
 namespace SKSNSimTools {
   SKSNSIMENUM::SKPERIOD FindSKPeriod(int rn /* run_number */) {
     auto checkRange = [] (int t, int b, int e) {
@@ -30,6 +35,16 @@ namespace SKSNSimTools {
     return SKSNSIMENUM::SKPERIOD::NSKPERIOD;
   }
 
+  int elapseday(int yy, int mm, int dd){
+    int eladay = -1;
+    elapseday_date_(&yy, &mm, &dd, &eladay);
+    return eladay;
+  }
+  int elapseday(int run){
+    int eladay = -1;
+    elapseday_run_(&run, &eladay);
+    return eladay;
+  }
 }
 
 namespace SKSNSimLiveTime {

--- a/src/SKSNSimUserConfiguration.cc
+++ b/src/SKSNSimUserConfiguration.cc
@@ -84,7 +84,7 @@ bool SKSNSimUserConfiguration::CheckRuntimeFactor() const {
   return !badhealth;
 }
 
-void ShowHelpDSNB(const char *argv0){
+void SKSNSimUserConfiguration::ShowHelpDSNB(const char *argv0){
   std::cout << argv0
     << " [-c,--customflux {flux_filename}]"
     << " [--energy_min {energy_MeV}]"
@@ -126,7 +126,7 @@ void ShowHelpDSNB(const char *argv0){
     << std::endl;
 }
 
-void ShowHelpSN(const char *argv0){
+void SKSNSimUserConfiguration::ShowHelpSN(const char *argv0){
 
   std::cout << argv0
     << " [-h,--help]"

--- a/src/SKSNSimVectorGenerator.cc
+++ b/src/SKSNSimVectorGenerator.cc
@@ -10,6 +10,7 @@
 #include "SKSNSimCrosssection.hh"
 #include "SKSNSimTools.hh"
 #include <typeinfo>
+#include <Math/Integrator.h> // For flux x xsec integration via ROOT
 
 using namespace SKSNSimPhysConst;
 
@@ -62,16 +63,27 @@ SKSNSimSNEventVector SKSNSimVectorGenerator::GenerateEventIBD() {
   static int static_runnum = -1;
   static int elapseday = -1;
   static double max_prob_elapseday = -1.;
+  static double flux_integral = -1.;
   if( static_runnum != m_runnum ){
     static_runnum = m_runnum;
     elapseday = SKSNSimTools::elapseday(m_runnum);
     max_prob_elapseday = FindMaxProb(flux,xsec, elapseday);
-    std::cout << "[GenerateEventIBD()] runnum = " << m_runnum << " => elapseday = " << elapseday << " maxP " << max_prob_elapseday << std::endl;
+
+    ROOT::Math::IntegratorOneDimOptions::SetDefaultAbsTolerance(1.e-6);
+    ROOT::Math::IntegratorOneDimOptions::SetDefaultRelTolerance(1.e-6);
+    auto func = std::bind([](const SKSNSimFluxModel &f, const SKSNSimCrosssectionModel &s, double e, int &eladay) {
+      return f.GetFlux(e, eladay, SKSNSimFluxModel::FLUXNUEB) * s.GetCrosssection(e);
+    }, std::ref(flux), std::ref(xsec), std::placeholders::_1, elapseday);
+    ROOT::Math::Integrator ig;
+    ig.SetFunction(func);
+    flux_integral = ig.Integral(GetEnergyMin(), GetEnergyMax());
+
+    std::cout << "[GenerateEventIBD()] runnum = " << m_runnum << " => elapseday = " << elapseday << " maxP " << max_prob_elapseday << " integral(fluxXxsec) " << flux_integral << " m_runtime_factor " << m_runtime_factor << " weight " << flux_integral * SKSNSimTools::GetNTargetP(m_generator_volume) / m_runtime_factor  << std::endl;
   }
 #ifdef DEBUG
   std::cout << "[GenerateEventIBD()] runnum = " << m_runnum << " => elapseday = " << elapseday << std::endl;
 #endif
-  ev.SetWeight( max_prob_elapseday );
+  ev.SetWeight( flux_integral * SKSNSimTools::GetNTargetP(m_generator_volume) / m_runtime_factor);
 
 
   auto SQ = [](double a){ return a*a;};
@@ -133,7 +145,7 @@ SKSNSimSNEventVector SKSNSimVectorGenerator::GenerateEventIBD() {
         hPositionRange = ZPINTK;
         break;
       case SKSNSIMENUM::TANKVOLUME::kTANKFULL: //entire detector volume (including OD)
-        rPositionRange = DITKTK;
+        rPositionRange = RTKTK;
         hPositionRange = ZPTKTK;
         break;
       default: //entire ID volume
@@ -253,7 +265,6 @@ SKSNSimSNEventVector SKSNSimVectorGenerator::GenerateEventIBDFlat() {
   {
     double rPositionRange = RINTK;
     double hPositionRange = ZPINTK;
-    const double FVCUT = 200.;
     switch (t)
     {
       case SKSNSIMENUM::TANKVOLUME::kIDFV: //Fiducial volume
@@ -265,7 +276,7 @@ SKSNSimSNEventVector SKSNSimVectorGenerator::GenerateEventIBDFlat() {
         hPositionRange = ZPINTK;
         break;
       case SKSNSIMENUM::TANKVOLUME::kTANKFULL: //entire detector volume (including OD)
-        rPositionRange = DITKTK;
+        rPositionRange = RTKTK;
         hPositionRange = ZPTKTK;
         break;
       default: //entire ID volume
@@ -1018,7 +1029,7 @@ std::vector<SKSNSimSNEventVector> SKSNSimVectorSNGenerator::MakeEvent(const doub
         hPositionRange = ZPINTK;
         break;
       case SKSNSIMENUM::TANKVOLUME::kTANKFULL: //entire detector volume (including OD)
-        rPositionRange = DITKTK;
+        rPositionRange = RTKTK;
         hPositionRange = ZPTKTK;
         break;
       default: //entire ID volume

--- a/src/elapseday_date.F
+++ b/src/elapseday_date.F
@@ -1,0 +1,24 @@
+! interface to skelapseday.F defined in SKOFL
+      subroutine elapseday_date(y,m,d,ed)
+        implicit none
+#include "skday.h"
+        integer y,m,d,ed
+        integer i_run
+        real ed_r
+
+        call skrunday
+
+        ed_r = 999999 ! skelapseday(nday,ntim)
+        do i_run = 65000,999999
+!           print *,i_run
+!           print *,i_run,ryear(i_run),rmon(i_run),rday(i_run),relapse(i_run)
+           if( (ryear(i_run).eq.y) .and.
+     $         (rmon(i_run).eq.m) .and.
+     $         (rday(i_run).le.d .and. d.le.rday(i_run))) then
+               ed_r = relapse(i_run)
+               exit
+           end if
+        end do
+        ed = int(ed_r)
+
+      end subroutine elapseday_date

--- a/src/elapseday_run.F
+++ b/src/elapseday_run.F
@@ -1,0 +1,15 @@
+!===============================================
+      subroutine elapseday_run(r,ed)
+!===============================================
+        implicit none
+#include "skday.h"
+        integer r,ed
+        integer i_run
+        real ed_r
+
+        call skrunday
+
+
+        ed = int(relapse(r))
+
+      end subroutine elapseday_run


### PR DESCRIPTION
This try to include day-by-day flux variation in order to adapt the reactor neutrino flux.  Those change should not affect the result and use of the SN burst simulation.

Note for this request:
* New dependency to SK wtlib 5.1 (available for only SK collaboration)
* Support of time dependent flux
* New file output, TTree of event weights
* Bugfix of event position in `SKSNSimVectorGenerator::GenerateEventIBD()`