### PR TITLE
Added "--outname_template" option in DSNB side

### DIFF
--- a/include/SKSNSimUserConfiguration.hh
+++ b/include/SKSNSimUserConfiguration.hh
@@ -39,6 +39,7 @@ class SKSNSimUserConfiguration{
     /* Output file related */
     std::string m_output_directory;
     std::string m_outputfile_prefix;
+    std::string m_outputfile_template;
     size_t m_num_per_file;
     bool m_eventvector_generation;
     SKSNSIMENUM::TANKVOLUME m_eventgen_volume;
@@ -88,6 +89,7 @@ class SKSNSimUserConfiguration{
 
       m_output_directory = GetDefaultOutputDirectory();
       m_outputfile_prefix = GetDefaultOutputPrefix();
+      m_outputfile_template = GetDefaultOutputNameTemplate();
       m_num_per_file = GetDefaultNumEventsPerFile();
       m_eventvector_generation = GetDefaultVectorGeneration();
       m_eventgen_volume = GetDefaultEventVolume();
@@ -142,6 +144,7 @@ class SKSNSimUserConfiguration{
     const static bool GetDefaultVectorGeneration () { return true; } 
     const static std::string GetDefaultOutputDirectory () { return "./vectout"; }
     const static std::string GetDefaultOutputPrefix () { return "snmcvect"; }
+    const static std::string GetDefaultOutputNameTemplate () { return ""; }
     const static size_t GetDefaultNumEvents () { return 1000;}
     const static size_t GetDefaultNumEventsPerFile () { return 1000; }
     const static unsigned GetDefaultRandomSeed () { return 42;}
@@ -175,6 +178,7 @@ class SKSNSimUserConfiguration{
     SKSNSimUserConfiguration &SetRuntimeFactor(double f){ m_factor_runtime = f; return *this;}
     SKSNSimUserConfiguration &SetOutputDirectory(std::string dir) { m_output_directory = dir; return *this;}
     SKSNSimUserConfiguration &SetOutputPrefix(std::string pref) { m_outputfile_prefix = pref; return *this;}
+    SKSNSimUserConfiguration &SetOutputNameTemplate(std::string tmp) { m_outputfile_template = tmp; return *this;}
     SKSNSimUserConfiguration &SetRandomSeed(unsigned s) { m_random_seed = s; m_randomgenerator->SetSeed(m_random_seed); return *this;}
     SKSNSimUserConfiguration &SetRuntimeRunBegin(int r) { m_runtime_runbegin = r; return *this;}
     SKSNSimUserConfiguration &SetRuntimeRunEnd(int r) { m_runtime_runend = r; return *this;}
@@ -200,6 +204,7 @@ class SKSNSimUserConfiguration{
     /* Output file related */
     std::string GetOutputDirectory() const { return m_output_directory;}
     std::string GetOutputPrefix() const { return m_outputfile_prefix;}
+    std::string GetOutputNameTemplate() const { return m_outputfile_template;}
     size_t GetNumEventsPerFile() const {return m_num_per_file;}
     bool   GetEventVectorGeneration() const { return m_eventvector_generation; }
     SKSNSIMENUM::TANKVOLUME GetEventgenVolume() const { return m_eventgen_volume; }

--- a/src/SKSNSimFileIO.cc
+++ b/src/SKSNSimFileIO.cc
@@ -131,6 +131,12 @@ std::vector<SKSNSimFileSet> GenerateOutputFileListNoRuntime(const SKSNSimUserCon
   auto genFileName = [](const SKSNSimUserConfiguration &c, int i){
     char buf[1000];
     snprintf(buf, 999, "%s/%s_%06d.root", c.GetOutputDirectory().c_str(), c.GetOutputPrefix().c_str(), i);
+    if( c.GetOutputNameTemplate() != SKSNSimUserConfiguration::GetDefaultOutputNameTemplate() ){
+      auto pos = c.GetOutputNameTemplate().find("RUNNUM");
+      auto pref = c.GetOutputNameTemplate().substr(0,pos);
+      auto suf  = c.GetOutputNameTemplate().substr(pos+6);
+      snprintf(buf, 999, "%s/%s%06d%s", c.GetOutputDirectory().c_str(), pref.c_str(), i, suf.c_str());
+    }
     return std::string(buf);
   };
 
@@ -161,7 +167,15 @@ std::vector<SKSNSimFileSet> GenerateOutputFileListRuntime(SKSNSimUserConfigurati
     auto vectio = std::make_unique<SKSNSimFileOutTFile>();
     const int run = std::get<0>(*it);
     std::stringstream ss;
-    ss << conf.GetOutputDirectory() << "/" << conf.GetOutputPrefix() << "." << std::setfill('0') << std::setw(6) << run << ".root";
+    if( conf.GetOutputNameTemplate() != SKSNSimUserConfiguration::GetDefaultOutputNameTemplate() ){
+      auto pos  = conf.GetOutputNameTemplate().find("RUNNUM");
+      auto pref = conf.GetOutputNameTemplate().substr(0,pos);
+      auto suf  = conf.GetOutputNameTemplate().substr(pos+6);
+      ss << conf.GetOutputDirectory() << "/" << pref << std::setfill('0') << std::setw(6) << run << suf;
+
+    } else {
+      ss << conf.GetOutputDirectory() << "/" << conf.GetOutputPrefix() << "." << std::setfill('0') << std::setw(6) << run << ".root";
+    }
     const std::string fname(ss.str());
 
     std::cout << "fname " << fname << " nev " << std::get<1>(*it) <<std::endl;

--- a/src/SKSNSimUserConfiguration.cc
+++ b/src/SKSNSimUserConfiguration.cc
@@ -98,6 +98,7 @@ void SKSNSimUserConfiguration::ShowHelpDSNB(const char *argv0){
     << " [--runtime_period {5/6}]"
     << " [--neventsperfile {int}]"
     << " [--outprefix {pref}]"
+    << " [--outname_template {template.RUNNUM.root}]"
     << " [--flatposflux]"
     << " [-h,--help]"
     << " [-s,--seed {unsigned}]"
@@ -119,6 +120,8 @@ void SKSNSimUserConfiguration::ShowHelpDSNB(const char *argv0){
     << " --runtime_period {5/6}: SK period for runtime normalization: SK-IV = 3, SK-V = 4, SK-VI = 5 ( default = " << SKSNSimUserConfiguration::GetDefaultRuntimePeriod() << " , -1 means that period is specified by runnnumber. see --runtime_{begin/end}.)" << std::endl
     << " --neventsperfile {int}: number of events per one file ( default = " << SKSNSimUserConfiguration::GetDefaultNumEventsPerFile() << " )" << std::endl
     << " --outprefix {pref}: prefix of output file name ( default = " << SKSNSimUserConfiguration::GetDefaultOutputPrefix() << " )" << std::endl
+    << " --outname_template {template.RUNNUM.root}: format of output filename in run-by-run mode ( default = " << SKSNSimUserConfiguration::GetDefaultOutputNameTemplate() << " )" << std::endl
+    << "                                            This option conflicts --outprefix. --outname_template has higher priority " << std::endl
     << " -h,--help: show this help" << std::endl
     << " -s,--seed {unsigned}: random seed ( default = " << SKSNSimUserConfiguration::GetDefaultRandomSeed() << " )" << std::endl
     << " {outputdirectory}: output direcotry. Same with -o,--outdir. This has higher priority."
@@ -210,6 +213,7 @@ void SKSNSimUserConfiguration::LoadFromArgsDSNB(int argc, char *argv[]){
       {"help",                no_argument, 0, 'h'},
       {"seed",          required_argument, 0, 's'},
       {"flatposflux",         no_argument, 0,   0},
+      {"outname_template", required_argument, 0,0}, // 15
       {0,                               0, 0,   0}
     };
 
@@ -240,6 +244,7 @@ void SKSNSimUserConfiguration::LoadFromArgsDSNB(int argc, char *argv[]){
           case 10: SetNumEventsPerFile(std::atoi(optarg)); break;
           case 11: SetOutputPrefix(optarg); break;
           case 14: SetDSNBFlatFlux(true); break;
+          case 15: SetOutputNameTemplate(optarg); break;
           default:
             ShowHelpDSNB(argv[0]);
             exit(EXIT_FAILURE);
@@ -367,6 +372,7 @@ void SKSNSimUserConfiguration::Dump() const {
   std::cout << "TimeNBins = " << GetTimeNBins() << std::endl;
   std::cout << "OutputDirecotry = " << GetOutputDirectory() << std::endl;
   std::cout << "OutputPrefix = " << GetOutputPrefix() << std::endl;
+  std::cout << "OutputNameTemplate = " << GetOutputNameTemplate() << std::endl;
   std::cout << "NumEventsPerFile = " << GetNumEventsPerFile() << std::endl;
   std::cout << "EventVectorGeneration = " << GetEventVectorGeneration() << std::endl;
   std::cout << "EventgenVolume = " << (int)GetEventgenVolume() << std::endl;


### PR DESCRIPTION
close #21

This includes new option for DSNB mode. As I suggested in the issue #21, it is useful to have flexible filename format. In order to realize that, I have prepared new option "--outname_template" option. 

Usage: the program generate the vectors as a filename of "vect.r085550.1.root" when "--outname_template vect.rRUNNUM.1.root" is specified.

This should not affect SN-burst program. 