### PR TITLE
24 output of nuance format

### DIFF
--- a/doc/guide_sksnsim.texi
+++ b/doc/guide_sksnsim.texi
@@ -105,6 +105,21 @@ Basically, you can run by just executing @command{main_dsnb(_new)} with wanted o
 Detail can be dumped by executing @command{main_dsnb(_new) --help}.
 Basically, you can run by just executing @command{main_dsnb(_new)} with wanted options you would like to change.
 
+@section Output format
+
+SKSNSim supports two type of output format, usual SKROOT and NUANCE format.
+These can be switched via the option @command{--outputformat}.
+
+In the NUANCE format, there are records of @command{nuance __interaction_mode__}, @command{vertex __x__ __y__ __z__ __time___}, and @command{track __pid__ __total_energy__ __dir_x__ __dir_y__ __dir_z__ __interaction_flag__}.
+@itemize
+@item
+@command{__interaction_mode__}: based on SKSNSim internal code
+@item
+@command{__pid__}: PDG_CODE
+@item
+@command{__ineraction_flag__}: 0 is the final state particle after interaction, -1 is initial state particle, -2 is final state particle before interactions. Only 0 should be propagated to detector simulation.
+@end itemize
+
 @section Detail parameters
 
 SKSNSim uses several parameters such as neutrino oscillation parameters. If you want to modify them, you need to check following files:

--- a/include/SKSNSimFileIO.hh
+++ b/include/SKSNSimFileIO.hh
@@ -5,6 +5,8 @@
 #ifndef SKSNSIMFILEIO_H_INCLUDED
 #define SKSNSIMFILEIO_H_INCLUDED
 
+#include <iostream>
+#include <fstream>
 #include <TFile.h>
 #include <TTree.h>
 #include <mcinfo.h>
@@ -56,6 +58,25 @@ class SKSNSimFileOutTFile : public SKSNSimFileOutput {
 
     void Open(const std::string fname, const bool including_snevtinfo);
     void Open(const std::string fname) { Open(fname, false);};
+    void Close();
+
+    void Write(const SKSNSimSNEventVector &);
+    void Write(const std::vector<SKSNSimSNEventVector> &vecs)
+    {for(auto it = vecs.begin(); it != vecs.end(); it++) Write(*it);};
+};
+
+class SKSNSimFileOutNuance : public SKSNSimFileOutput {
+  private:
+
+    Double_t weight;
+    std::unique_ptr<std::ofstream> ofs;
+
+  public:
+    SKSNSimFileOutNuance () {};
+    SKSNSimFileOutNuance (const std::string fname) { Open(fname); }
+    ~SKSNSimFileOutNuance (){ if( ofs->is_open()) Close(); }
+
+    void Open(const std::string fname);
     void Close();
 
     void Write(const SKSNSimSNEventVector &);

--- a/include/SKSNSimUserConfiguration.hh
+++ b/include/SKSNSimUserConfiguration.hh
@@ -23,6 +23,7 @@ class SKSNSimUserConfiguration{
   public:
     enum struct MODERUNTIME   { kEVNUM = 0, kRUNTIMERUNNUM, kRUNTIMEPERIOD, kNMODERUNTIME };
     enum struct MODEGENERATOR { kSNBURST = 0, kDSNB, kNMODEGENERATOR };
+    enum struct MODEOFILE { kSKROOT = 0, kNUANCE, kNMODEOFILE };
 
   private:
     /* mode */
@@ -43,6 +44,7 @@ class SKSNSimUserConfiguration{
     size_t m_num_per_file;
     bool m_eventvector_generation;
     SKSNSIMENUM::TANKVOLUME m_eventgen_volume;
+    MODEOFILE m_mode_ofile;
 
     /* DSNB runtime normalization related */
     size_t m_num_events;
@@ -77,6 +79,9 @@ class SKSNSimUserConfiguration{
     bool CheckNumEvents() const;
     bool CheckNormRuntime() const;
     bool CheckRuntimeFactor() const;
+    bool CheckOFileMode() const { return m_mode_ofile != MODEOFILE::kNMODEOFILE; }
+
+    static std::string convOFileModeString(MODEOFILE m);
 
   public:
     void SetDefaultConfiguation() {
@@ -93,6 +98,7 @@ class SKSNSimUserConfiguration{
       m_num_per_file = GetDefaultNumEventsPerFile();
       m_eventvector_generation = GetDefaultVectorGeneration();
       m_eventgen_volume = GetDefaultEventVolume();
+      m_mode_ofile = GetDefaultOFileMode();
 
       m_num_events = GetDefaultNumEvents();
       m_runtime_normalization = GetDefaultRuntimeNormalization();
@@ -148,6 +154,7 @@ class SKSNSimUserConfiguration{
     const static size_t GetDefaultNumEvents () { return 1000;}
     const static size_t GetDefaultNumEventsPerFile () { return 1000; }
     const static unsigned GetDefaultRandomSeed () { return 42;}
+    const static MODEOFILE GetDefaultOFileMode () { return MODEOFILE::kSKROOT; }
     const static int GetDefaultRuntimeBegin () { return (int) SKSNSIMENUM::SKPERIODRUN::SKVIBEGIN;}
     const static int GetDefaultRuntimeEnd () { return (int) SKSNSIMENUM::SKPERIODRUN::SKVIEND;}
     const static int GetDefaultRuntimePeriod() { return -1; /* using RuntimeBegin/End */}
@@ -192,6 +199,8 @@ class SKSNSimUserConfiguration{
     SKSNSimUserConfiguration &SetNeutrinoOscType( int t) { m_nuosc_type = (SKSNSIMENUM::NEUTRINOOSCILLATION)t; return *this; }
     SKSNSimUserConfiguration &SetRunnum(int r) { m_runnum = r; return *this; }
     SKSNSimUserConfiguration &SetSubRunnum(int r) { m_subrunnum = r; return *this; }
+    SKSNSimUserConfiguration &SetOFileMode ( MODEOFILE m ) { m_mode_ofile = m; return *this; }
+    SKSNSimUserConfiguration &SetOFileMode ( std::string s, bool exit_if_wrong = true );
 
     /* Event range related */
     double GetFluxEnergyMin() const { return m_energy_min;}
@@ -208,6 +217,8 @@ class SKSNSimUserConfiguration{
     size_t GetNumEventsPerFile() const {return m_num_per_file;}
     bool   GetEventVectorGeneration() const { return m_eventvector_generation; }
     SKSNSIMENUM::TANKVOLUME GetEventgenVolume() const { return m_eventgen_volume; }
+    MODEOFILE GetOFileMode() const { return m_mode_ofile; }
+    std::string GetOFileModeString() const;
 
     /* DSNB runtime normalization related */
     bool   GetNormRuntime() const { return m_runtime_normalization;}

--- a/main_dsnb_new.cc
+++ b/main_dsnb_new.cc
@@ -51,7 +51,7 @@ int main(int argc, char **argv){
 
   for(auto it = flist.begin(); it != flist.end(); it++){
     /* Open file IO and then generate events from file configuration */
-    auto vectio = std::make_unique<SKSNSimFileOutTFile>(it->GetFileName());
+    auto vectio = std::make_unique<SKSNSimFileOutNuance>(it->GetFileName());
     vectgen->SetRUNNUM( it->GetRun() );
     vectgen->SetSubRUNNUM( it->GetSubrun() );
     auto evt_buffer = vectgen->GenerateEvents(it->GetNumEvents());

--- a/main_dsnb_new.cc
+++ b/main_dsnb_new.cc
@@ -51,7 +51,13 @@ int main(int argc, char **argv){
 
   for(auto it = flist.begin(); it != flist.end(); it++){
     /* Open file IO and then generate events from file configuration */
-    auto vectio = std::make_unique<SKSNSimFileOutNuance>(it->GetFileName());
+    std::unique_ptr<SKSNSimFileOutput> vectio;
+    if( config->GetOFileMode() == SKSNSimUserConfiguration::MODEOFILE::kNUANCE ) vectio.reset(new SKSNSimFileOutNuance(it->GetFileName()));
+    else if( config->GetOFileMode() == SKSNSimUserConfiguration::MODEOFILE::kSKROOT ) vectio.reset(new SKSNSimFileOutTFile(it->GetFileName()));
+    else { 
+      std::cout << "ERR: strange output format " << std::endl;
+      exit(EXIT_FAILURE);
+    }
     vectgen->SetRUNNUM( it->GetRun() );
     vectgen->SetSubRUNNUM( it->GetSubrun() );
     auto evt_buffer = vectgen->GenerateEvents(it->GetNumEvents());

--- a/main_snburst_new.cc
+++ b/main_snburst_new.cc
@@ -62,8 +62,8 @@ int main( int argc, char ** argv )
 
   auto flist = GenerateOutputFileList(*config);
   for(auto it = flist.begin(); it != flist.end(); it++){
-    auto vectio = std::make_unique<SKSNSimFileOutTFile>();
-    vectio->Open(it->GetFileName(), true);
+    auto vectio = std::make_unique<SKSNSimFileOutNuance>();
+    vectio->Open(it->GetFileName());
     vectio->Write(buffer);
     vectio->Close();
   }

--- a/main_snburst_new.cc
+++ b/main_snburst_new.cc
@@ -62,8 +62,15 @@ int main( int argc, char ** argv )
 
   auto flist = GenerateOutputFileList(*config);
   for(auto it = flist.begin(); it != flist.end(); it++){
-    auto vectio = std::make_unique<SKSNSimFileOutNuance>();
-    vectio->Open(it->GetFileName());
+    std::unique_ptr<SKSNSimFileOutput> vectio;
+    if( config->GetOFileMode() == SKSNSimUserConfiguration::MODEOFILE::kNUANCE ) {
+      vectio.reset( new SKSNSimFileOutNuance());
+      vectio->Open(it->GetFileName());
+    } else if( config->GetOFileMode() == SKSNSimUserConfiguration::MODEOFILE::kSKROOT ) {
+      auto vectio_tmp = new SKSNSimFileOutTFile();
+      vectio_tmp->Open(it->GetFileName(), true);
+      vectio.reset( vectio_tmp );
+    }
     vectio->Write(buffer);
     vectio->Close();
   }

--- a/src/SKSNSimFileIO.cc
+++ b/src/SKSNSimFileIO.cc
@@ -365,7 +365,7 @@ void SKSNSimFileOutNuance::Write(const SKSNSimSNEventVector &ev) {
     }
     int mode = -9999;
     if( ev.GetTrackICRNVC(i) != 0 ) mode = 0;
-    else if ( ev.GetTrackIORGVC(i) != 0 ) mode = -1;
+    else if ( ev.GetTrackIFLGVC(i) != 0 ) mode = -1;
     else mode = -2;
     return "track "
       + std::to_string(ev.GetTrackPID(i)) + " "

--- a/src/SKSNSimFileIO.cc
+++ b/src/SKSNSimFileIO.cc
@@ -337,9 +337,13 @@ void SKSNSimFileOutNuance::Write(const SKSNSimSNEventVector &ev) {
   auto convReactionMode = [](const SKSNSimSNEventVector &ev) {
     return "nuance " + std::to_string(ev.GetSNEvtInfoRType());};
   auto convVertex = [] (const SKSNSimSNEventVector &ev) {
-    return ( "vertex " + std::to_string(ev.GetSNEvtInfoRVtx(0)) + " "
-        + std::to_string(ev.GetSNEvtInfoRVtx(1)) + " "
-        + std::to_string(ev.GetSNEvtInfoRVtx(2)) + " " 
+    return ( "vertex "
+        //+ std::to_string(ev.GetSNEvtInfoRVtx(0)) + " "
+        //+ std::to_string(ev.GetSNEvtInfoRVtx(1)) + " "
+        //+ std::to_string(ev.GetSNEvtInfoRVtx(2)) + " " 
+        + std::to_string(ev.GetVertexPositionX(0)) + " "
+        + std::to_string(ev.GetVertexPositionY(0)) + " "
+        + std::to_string(ev.GetVertexPositionZ(0)) + " "
         + std::to_string(ev.GetSNEvtInfoRTime())
           );
   };

--- a/src/SKSNSimFileIO.cc
+++ b/src/SKSNSimFileIO.cc
@@ -129,9 +129,11 @@ std::vector<SKSNSimFileSet> GenerateOutputFileListNoRuntime(const SKSNSimUserCon
   int nfile = conf.GetNumEvents() / conf.GetNumEventsPerFile();
   int nfile_rem = conf.GetNumEvents() % conf.GetNumEventsPerFile();
 
-  auto genFileName = [](const SKSNSimUserConfiguration &c, int i){
+  const std::string suffix = ( conf.GetOFileMode() == SKSNSimUserConfiguration::MODEOFILE::kSKROOT ? "root" : "txt");
+
+  auto genFileName = [](const SKSNSimUserConfiguration &c, int i, const std::string suffix){
     char buf[1000];
-    snprintf(buf, 999, "%s/%s_%06d.root", c.GetOutputDirectory().c_str(), c.GetOutputPrefix().c_str(), i);
+    snprintf(buf, 999, "%s/%s_%06d.%s", c.GetOutputDirectory().c_str(), c.GetOutputPrefix().c_str(), i, suffix.c_str());
     if( c.GetOutputNameTemplate() != SKSNSimUserConfiguration::GetDefaultOutputNameTemplate() ){
       auto pos = c.GetOutputNameTemplate().find("RUNNUM");
       auto pref = c.GetOutputNameTemplate().substr(0,pos);
@@ -142,11 +144,11 @@ std::vector<SKSNSimFileSet> GenerateOutputFileListNoRuntime(const SKSNSimUserCon
   };
 
   for(int i = 0; i < nfile; i++){
-    auto fn = genFileName(conf, i);
+    auto fn = genFileName(conf, i, suffix);
     flist.push_back(SKSNSimFileSet(fn, conf.GetRunnum(), conf.GetSubRunnum(), conf.GetNumEventsPerFile()));
   }
   if( nfile_rem != 0){
-    auto fn = genFileName(conf, nfile);
+    auto fn = genFileName(conf, nfile, suffix);
     flist.push_back(SKSNSimFileSet(fn, conf.GetRunnum(), conf.GetSubRunnum(), nfile_rem));
   }
   return flist;
@@ -175,7 +177,8 @@ std::vector<SKSNSimFileSet> GenerateOutputFileListRuntime(SKSNSimUserConfigurati
       ss << conf.GetOutputDirectory() << "/" << pref << std::setfill('0') << std::setw(6) << run << suf;
 
     } else {
-      ss << conf.GetOutputDirectory() << "/" << conf.GetOutputPrefix() << "." << std::setfill('0') << std::setw(6) << run << ".root";
+      std::string suffix = (conf.GetOFileMode() == SKSNSimUserConfiguration::MODEOFILE::kSKROOT ? "root" : "txt");
+      ss << conf.GetOutputDirectory() << "/" << conf.GetOutputPrefix() << "." << std::setfill('0') << std::setw(6) << run << "." << suffix;
     }
     const std::string fname(ss.str());
 

--- a/src/SKSNSimVectorGenerator.cc
+++ b/src/SKSNSimVectorGenerator.cc
@@ -222,6 +222,9 @@ SKSNSimSNEventVector SKSNSimVectorGenerator::GenerateEventIBD() {
 
   ev.SetRunnum(m_runnum);
   ev.SetSubRunnum(m_subrunnum);
+  const double rvtx[3] = {xyz.x, xyz.y, xyz.z };
+  const double rdir[3] = {-nuDir.x, -nuDir.y, -nuDir.z };
+  ev.SetSNEvtInfo( 0 /* IBD */, 0.0, - PDG_ELECTRON_NEUTRINO, nuEne, rdir, rvtx );
 
   return ev;
 }
@@ -354,6 +357,9 @@ SKSNSimSNEventVector SKSNSimVectorGenerator::GenerateEventIBDFlat() {
 
   ev.SetRunnum(m_runnum);
   ev.SetSubRunnum(m_subrunnum);
+  const double rvtx[3] = {xyz.x, xyz.y, xyz.z };
+  const double rdir[3] = {-nuDir.x, -nuDir.y, -nuDir.z };
+  ev.SetSNEvtInfo( 0 /* IBD */, 0.0, - PDG_ELECTRON_NEUTRINO, nuEne, rdir, rvtx );
 
   return ev;
 }


### PR DESCRIPTION
Implemented NUANCE output format which is switchable via ``--outputformat`` option as discussed in the issue #24.
At this moment, interaction code does not refere official NUANCE format. But I think it would be fine.