### PR TITLE
User-specified data directory and download script of flux data

### DIFF
--- a/doc/guide_sksnsim.texi
+++ b/doc/guide_sksnsim.texi
@@ -77,7 +77,8 @@ Compiled binaries and shared library are put into @file{bin} and @file{lib} dire
 @section Input data
 
 The flux data are distributed other way.
-After the extraction of the tar.gz file, please specify the data directory via the environmental variable, @code{SKSNSIMDIR}.
+After the extraction of the tar.gz file, please specify the data directory via the environmental variable, @code{SKSNSIMFLUXDIR}.
+The flux data for the SN burst and DSNB should be in the @code{$@{SKSNSIMFLUXDIR@}/snburst} and @code{$@{SKSNSIMFLUXDIR@}/dsnb} respectively.
 
 
 @section Binaries

--- a/doc/guide_sksnsim.texi
+++ b/doc/guide_sksnsim.texi
@@ -190,6 +190,26 @@ class SKSNSimFluxModel @{
 If you want to implement new model, please implement your class with inheriting this interface class.
 If you have flux model as CSV file, you might be able to use the @code{SKSNSimDSNBFluxCustom} with only loading your CSV file.
 
+@node Data
+@chapter Distributed flux data
+
+The distributed data consists of the SN burst flux of some models and the DSNB spectrum.
+The SN burst flux includes following models:
+@itemize
+@item Nakazato model
+@item Mori model
+@item Wilson model
+@item Tamborra model
+@item Hudelphole model
+@item Fischer model
+@item Liebendorfer model
+@end itemize
+The DSNB flux includes only Horiuchi model:
+@itemize
+@item Horiuch model
+@end itemize
+
+
 
 
 @bye

--- a/doc/guide_sksnsim.texi
+++ b/doc/guide_sksnsim.texi
@@ -74,6 +74,12 @@ $ make clean &&  make
 
 Compiled binaries and shared library are put into @file{bin} and @file{lib} directory.
 
+@section Input data
+
+The flux data are distributed other way.
+After the extraction of the tar.gz file, please specify the data directory via the environmental variable, @code{SKSNSIMDIR}.
+
+
 @section Binaries
 @subsection For SN burst
 

--- a/download_data.sh
+++ b/download_data.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+UPSTREAMURL="https://github.com/SKSNSim/SKSNSim/releases/download/v1.2.0-data/supernova_data.tar.gz"
+
+if [ -z "${SKSNSIMDATADIR}" ]; then
+  echo "Environmental variable \"SKSNSIMDATADIR\" is not defined."
+  echo "Please configure the variable."
+  exit 1
+fi
+
+if [ ! -d ${SKSNSIMDATADIR} ]; then
+  echo "The data directory does not exit."
+  echo "Making directory "$SKSNSIMDATADIR
+  mkdir -p $SKSNSIMDATADIR
+fi
+
+target=${SKSNSIMDATADIR}/supernova_data.tar.gz
+
+which wget || (echo "no wget on your system. Please download manually from \"${UPSTREAMURL}\"." && exit 1)
+wget -O $target $UPSTREAMURL
+
+origdir=$(pwd)
+cd $SKSNSIMDATADIR && tar -xvzf $target
+cd $origdir
+

--- a/include/SKSNSimFlux.hh
+++ b/include/SKSNSimFlux.hh
@@ -14,7 +14,10 @@
 #include <iostream>
 #include <string>
 #include <set>
+#include <cstdlib>
 #include "SKSNSimTools.hh"
+
+constexpr char DATADIRVARIABLENAME[] = "SKSNSIMDIR";
 
 class SKSNSimFluxModel {
   public:
@@ -120,14 +123,29 @@ class SKSNSimSNFluxNakazatoFormat : public SKSNSimBinnedFluxModel {
 
   public:
     SKSNSimSNFluxNakazatoFormat(){
-      flux = std::make_unique<SKSNSimSNFluxCustom>( "/home/sklowe/supernova/data/nakazato/intp2002.data" );
+      if( const char * env_p = std::getenv(DATADIRVARIABLENAME) )
+        flux = std::make_unique<SKSNSimSNFluxCustom>( std::string(env_p) + "/data/nakazato/intp2002.data" );
+      else {
+        std::cout << "The environmental variable \"" << DATADIRVARIABLENAME << "\" is not defined. Please set it..." << std::endl;
+        exit(EXIT_FAILURE);
+      }
     }
     SKSNSimSNFluxNakazatoFormat(std::string mname){
-      flux = std::make_unique<SKSNSimSNFluxCustom>( "/home/sklowe/supernova/data/" + mname );
+      if( const char * env_p = std::getenv(DATADIRVARIABLENAME) )
+        flux = std::make_unique<SKSNSimSNFluxCustom>( std::string(env_p) + "/data/" + mname );
+      else {
+        std::cout << "The environmental variable \"" << DATADIRVARIABLENAME << "\" is not defined. Please set it..." << std::endl;
+        exit(EXIT_FAILURE);
+      }
     }
     ~SKSNSimSNFluxNakazatoFormat(){}
     void SetModel(std::string mname) {
-      flux.reset(new SKSNSimSNFluxCustom("/home/sklowe/supernova/data/" + mname));
+      if( const char * env_p = std::getenv(DATADIRVARIABLENAME) )
+        flux.reset(new SKSNSimSNFluxCustom( std::string(env_p) + "/data/" + mname));
+      else {
+        std::cout << "The environmental variable \"" << DATADIRVARIABLENAME << "\" is not defined. Please set it..." << std::endl;
+        exit(EXIT_FAILURE);
+      }
     }
     double GetFlux(const double e, const double t, const FLUXNUTYPE type) const { return flux->GetFlux(e,t,type); }
     double GetEnergyLimitMax() const { return flux->GetEnergyLimitMax(); }
@@ -147,7 +165,12 @@ class SKSNSimSNFluxNakazato : public SKSNSimBinnedFluxModel {
     std::unique_ptr<SKSNSimSNFluxCustom> flux;; // TODO modify to changeable file name (model)
   public:
     SKSNSimSNFluxNakazato(){
-      flux = std::make_unique<SKSNSimSNFluxCustom>( "/home/sklowe/supernova/data/nakazato/intp2002.data" );
+      if( const char * env_p = std::getenv(DATADIRVARIABLENAME) )
+        flux = std::make_unique<SKSNSimSNFluxCustom>( std::string(env_p) + "/data/nakazato/intp2002.data" );
+      else {
+        std::cout << "The environmental variable \"" << DATADIRVARIABLENAME << "\" is not defined. Please set it..." << std::endl;
+        exit(EXIT_FAILURE);
+      }
     }
     ~SKSNSimSNFluxNakazato(){}
     double GetFlux(const double e, const double t, const FLUXNUTYPE type) const { return flux->GetFlux(e,t,type); }
@@ -168,7 +191,12 @@ class SKSNSimFluxDSNBHoriuchi : SKSNSimFluxModel {
     std::unique_ptr<SKSNSimDSNBFluxCustom> customflux;
   public:
     SKSNSimFluxDSNBHoriuchi(){
-      customflux = std::make_unique<SKSNSimDSNBFluxCustom>("./dsnb_flux/horiuchi/8MeV_Nominal.dat");
+      if( const char * env_p = std::getenv(DATADIRVARIABLENAME) )
+        customflux = std::make_unique<SKSNSimDSNBFluxCustom>( std::string(env_p) +"/dsnb/horiuchi/8MeV_Nominal.dat");
+      else {
+        std::cout << "The environmental variable \"" << DATADIRVARIABLENAME << "\" is not defined. Please set it..." << std::endl;
+        exit(EXIT_FAILURE);
+      }
       customflux->AddSupoortedNuTypes(std::set<FLUXNUTYPE>({FLUXNUEB}));
     }
     ~SKSNSimFluxDSNBHoriuchi (){}

--- a/include/SKSNSimFlux.hh
+++ b/include/SKSNSimFlux.hh
@@ -17,7 +17,7 @@
 #include <cstdlib>
 #include "SKSNSimTools.hh"
 
-constexpr char DATADIRVARIABLENAME[] = "SKSNSIMDIR";
+constexpr char DATADIRVARIABLENAME[] = "SKSNSIMFLUXDIR";
 
 class SKSNSimFluxModel {
   public:

--- a/include/SKSNSimFlux.hh
+++ b/include/SKSNSimFlux.hh
@@ -124,7 +124,7 @@ class SKSNSimSNFluxNakazatoFormat : public SKSNSimBinnedFluxModel {
   public:
     SKSNSimSNFluxNakazatoFormat(){
       if( const char * env_p = std::getenv(DATADIRVARIABLENAME) )
-        flux = std::make_unique<SKSNSimSNFluxCustom>( std::string(env_p) + "/data/nakazato/intp2002.data" );
+        flux = std::make_unique<SKSNSimSNFluxCustom>( std::string(env_p) + "/snburst/nakazato/intp2002.data" );
       else {
         std::cout << "The environmental variable \"" << DATADIRVARIABLENAME << "\" is not defined. Please set it..." << std::endl;
         exit(EXIT_FAILURE);
@@ -132,7 +132,7 @@ class SKSNSimSNFluxNakazatoFormat : public SKSNSimBinnedFluxModel {
     }
     SKSNSimSNFluxNakazatoFormat(std::string mname){
       if( const char * env_p = std::getenv(DATADIRVARIABLENAME) )
-        flux = std::make_unique<SKSNSimSNFluxCustom>( std::string(env_p) + "/data/" + mname );
+        flux = std::make_unique<SKSNSimSNFluxCustom>( std::string(env_p) + "/snburst/" + mname );
       else {
         std::cout << "The environmental variable \"" << DATADIRVARIABLENAME << "\" is not defined. Please set it..." << std::endl;
         exit(EXIT_FAILURE);
@@ -141,7 +141,7 @@ class SKSNSimSNFluxNakazatoFormat : public SKSNSimBinnedFluxModel {
     ~SKSNSimSNFluxNakazatoFormat(){}
     void SetModel(std::string mname) {
       if( const char * env_p = std::getenv(DATADIRVARIABLENAME) )
-        flux.reset(new SKSNSimSNFluxCustom( std::string(env_p) + "/data/" + mname));
+        flux.reset(new SKSNSimSNFluxCustom( std::string(env_p) + "/snburst/" + mname));
       else {
         std::cout << "The environmental variable \"" << DATADIRVARIABLENAME << "\" is not defined. Please set it..." << std::endl;
         exit(EXIT_FAILURE);
@@ -166,7 +166,7 @@ class SKSNSimSNFluxNakazato : public SKSNSimBinnedFluxModel {
   public:
     SKSNSimSNFluxNakazato(){
       if( const char * env_p = std::getenv(DATADIRVARIABLENAME) )
-        flux = std::make_unique<SKSNSimSNFluxCustom>( std::string(env_p) + "/data/nakazato/intp2002.data" );
+        flux = std::make_unique<SKSNSimSNFluxCustom>( std::string(env_p) + "/snburst/nakazato/intp2002.data" );
       else {
         std::cout << "The environmental variable \"" << DATADIRVARIABLENAME << "\" is not defined. Please set it..." << std::endl;
         exit(EXIT_FAILURE);


### PR DESCRIPTION
This tries to resolve #27 for non-SK collaborator. These changes enable to change data directory via the environmental variable "SKSNSIMDIR". And also, I added a script to download the SN/DSNB data.