### PR TITLE
Auto-generated  release note

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,7 +5,6 @@ changelog:
     labels:
       - ignore-for-release
     authors:
-      - octocat
   categories:
     - title: Breaking Changes 🛠
       labels:


### PR DESCRIPTION
I have added the template file to generate the relase note automatically. The file is baed on this document https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations.