### PR TITLE
Container build support (reference)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,25 +14,26 @@ ifdef SKOFL_ROOT
 include $(SKOFL_ROOT)/config.gmk
 endif
 
-LOCAL_INC	+= -I./include/
+LOCAL_INC = -I./include
+LOCAL_INC += -I$(SKOFL_ROOT)/include
 
 CXX=g++
 FC=gfortran
 LN = ln -sf
 
-CXXFLAGS +=$(shell root-config --cflags --libs) -fPIC -lstdc++ -lgsl -lgslcblas -lm
-CXXFLAGS += -DNO_EXTERN_COMMON_POINTERS #-DDEBUG
+
+CXXFLAGS += -I/mnt/sim/deps/root_v5.34.38_install/include $(shell root-config --cflags --libs) -fPIC -lstdc++ -lgsl -lgslcblas -lm
+CXXFLAGS += -DNO_EXTERN_COMMON_POINTERS -DSKINTERNAL
 CXXFLAGS += $(LOCAL_INC)
-ifdef SKOFL_ROOT
-CXXFLAGS += -DSKINTERNAL
-endif
-# if you want to use lates neutrino oscillation parameter, please comment out next line
-#CXXFLAGS += -DORIGINAL_NUOSCPARAMETER
+CXXFLAGS += -std=gnu++14
+# SKINTERNAL is now always defined
 
 FCFLAGS += -w -fPIC -lstdc++
 
 ifndef SKOFL_ROOT
 LDLIBS=$(shell root-config --libs)
+LDLIBS += -L/mnt/sim/deps/skofl/r32697/lib -lmcinfo -lsnevtinfo  # link SKOFL libraries statically
+LDLIBS += -Wl,-rpath,/mnt/sim/deps/skofl/r32697/lib  # set rpath to find SKOFL libraries at runtime
 endif
 
 ifdef SKOFL_ROOT
@@ -55,6 +56,7 @@ OBJS = $(patsubst src/%.cc, obj/%.o, $(filter %.cc, $(SRCS)))
 ifdef SKOFL_ROOT
 OBJS += $(patsubst src/%.F, obj/%.o, $(filter %.F, $(SRCS)))
 endif
+
 
 MAINSRCS = $(wildcard *.cc)
 MAINSRCS += $(wildcard *.F)

--- a/doc/container-patches.md
+++ b/doc/container-patches.md
@@ -1,0 +1,106 @@
+#################################################################################################
+Patches for SKSNSim to work the SNBurstPipeline project                                                    
+SKSNSim forked from https://github.com/SKSNSim/SKSNSim (Using the most current version as of 13 July 2026)  #
+#################################################################################################
+
+##################
+Nikolas TC Boily #
+13 July 2026     #
+##################
+
+Upstream bases for the 2026-07 upgrade:
+  SKSNSim: https://github.com/SKSNSim/SKSNSim.git
+           branch main @ ea3e3a3 (2026-06-01, "bug modification: the configuration is
+           defaulting to DSNB configuration")
+
+download_data.sh:
+    Update data dir to fit within the container and extract the values to the top level.
+
+main_snburst.cc:
+    Update path of TRandom3 in the #include block to work in the container root path.
+
+reweight.cc:
+    Update path of TFile and TTree in the #include block for container compatability of root.
+
+GNUmakefile:
+    SKINTERNAL flag is needed for vector files to generate fully. Without it enabled, the 
+    vector files do not fill the MCInfo and SNEvInfo, which leaves empty branches and
+    incompatabilities with SKG4.
+
+    Define SKINTERNAL constantly to enable these methods (which needs specific undef later
+    to bypass fortran code that is not available in the container).
+
+    Additional edits:
+
+        Statically link the SKOFL libraries at compile so it can be built with the container's
+        structure.
+
+        Add SKROOT_LIBDIR
+
+        Include path is $(SKOFL_ROOT)/include (env-driven); the no-SKOFL_ROOT fallback
+        branch links and rpaths against /mnt/sim/deps/skofl/r32697/lib (updated from the
+        old merged cern/2005 tree in the v1.2.0 deps layout split).
+
+
+SKSNSimCrosssection.cc:
+    Undef SKINTERNAL to bypass Fortran routines and use the C++ implementations that are available
+    within the SKOFL libraries in the container.
+
+
+SKSNSimVectorGenerator.cc:
+    Update path of TRandom3 to the container root path.
+
+    Undefine SKINTERNAL to bypass the fortran routine for sn_sun_dir_
+
+    Bool m_sn_dir_set added for the sn direction functionality
+
+    Line 452:
+        Fixed #ifdef SKITERNAL typo --> SKINTERNAL
+        Caused the sn_sundir_ branch to be dead code within the SKOFL build.
+
+    Line 441-451: 
+        Added block to set sdir if m_sn_dir_set is true.
+
+    Line 642-646: 
+        Added progress report to Tbins and Ebins.
+
+    Lines 1140-1142: 
+        Added progress report for fillevent.
+
+SKSNSimVectorGenerator.hh:
+    Line 329:
+        Added bool m_sn_dir_set
+
+    Line 391-398:
+        Added void function SetSNDir to set sn dir.
+        Added GetSNDir and GetSNDirSet helper functions.
+
+SKSNSimUserConfiguration.cc:
+    Added help lines for the sndir implementations
+    Added SNDir implementation for user configuration to be stored for vector generation.
+
+SKSNSimUserConfiguration.hh:
+    Added double m_sn_dir[3] and bool m_sn_dir_set for sn direction functionality 
+
+    Lines 115-120: 
+        Set default values for sn dir parameters
+
+    Added GetDefaultSNDirX(Y/Z) for default direction
+
+    Lines 225-230: 
+        Added sndir SKSNSimUserConfiguration processes for setting the sn direction. Also added
+        helper functions GetSNDir and GetSNDirSet to return their states.
+
+SKSNSimFileIO.cc:
+    Updated path for TFile and TTree to match container paths for root.
+
+SKSNSimTools.cc:
+    Undef skinteranl to bypass fortran routine for elapseday.
+
+
+Relevant for the SNBurstPipeline container:
+setup/build_libsnevtinfo.sh (not SKSNSim source, but part of its container build chain):
+    Rebuilds libsnevtinfo.so from ${SKOFL_ROOT}/src/skroot inside the container; paths
+    updated to the deps/skofl/<release> layout. The rootcint call needs the cint stub
+    include dirs (cint/cint/{include,stl,lib}) to run on the container's ROOT install --
+    same fix as the SKG4 GNUmakefile rootcint recipe (see SKG4-Patches.txt).

--- a/download_data.sh
+++ b/download_data.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-#UPSTREAMURL="https://github.com/SKSNSim/SKSNSim/releases/download/v1.2.0-data/supernova_data.tar.gz"
 UPSTREAMURL="https://github.com/SKSNSim/SKSNSim/releases/download/v1.2.0-data/supernova_data_260508.tar.gz"
 
 if [ -z "${SKSNSIMDATADIR}" ]; then
@@ -9,18 +8,19 @@ if [ -z "${SKSNSIMDATADIR}" ]; then
   exit 1
 fi
 
-if [ ! -d ${SKSNSIMDATADIR} ]; then
-  echo "The data directory does not exit."
-  echo "Making directory "$SKSNSIMDATADIR
-  mkdir -p $SKSNSIMDATADIR
+extractdir=$(dirname "${SKSNSIMDATADIR}")
+
+if [ ! -d ${extractdir} ]; then
+  echo "The data directory does not exist."
+  echo "Making directory "${extractdir}
+  mkdir -p ${extractdir}
 fi
 
-target=${SKSNSIMDATADIR}/supernova_data_260508.tar.gz
+target=${extractdir}/supernova_data_260508.tar.gz
 
 which wget || (echo "no wget on your system. Please download manually from \"${UPSTREAMURL}\"." && exit 1)
 wget -O $target $UPSTREAMURL
 
 origdir=$(pwd)
-cd $SKSNSIMDATADIR && tar -xvzf $target
+cd ${extractdir} && tar -xvzf $target
 cd $origdir
-

--- a/example/reweight.cc
+++ b/example/reweight.cc
@@ -16,8 +16,8 @@
 #include <cstdlib>
 #define BOOST_FILESYSTEM_NO_DEPRECATED
 #include <boost/filesystem.hpp>
-#include <TFile.h>
-#include <TTree.h>
+#include "root/TFile.h"
+#include "root/TTree.h"
 #include <TVector3.h>
 #include <TMath.h>
 #include <SKSNSimCrosssection.hh>

--- a/include/SKSNSimUserConfiguration.hh
+++ b/include/SKSNSimUserConfiguration.hh
@@ -60,6 +60,8 @@ class SKSNSimUserConfiguration{
 
     /* SN related */
     double m_sndistance_kpc;
+    double m_sn_dir[3];    // added for sndir (patch)
+    bool m_sn_dir_set;    // added for sndir (patch)
 
     /* Physics related */
     SKSNSIMENUM::NEUTRINOOSCILLATION m_nuosc_type;
@@ -110,6 +112,12 @@ class SKSNSimUserConfiguration{
       m_runnum = GetDefaultRunnum();
       m_subrunnum = GetDefaultSubRunnum();
 
+      // Added for sndir (patch)
+      m_sn_dir[0] = GetDefaultSNDirX();
+      m_sn_dir[1] = GetDefaultSNDirY();
+      m_sn_dir[2] = GetDefaultSNDirZ();
+      m_sn_dir_set = false; // by default, the direction is not set.
+
       m_sndistance_kpc = GetDefaultSNDistanceKPC();
       m_snburst_fluxmodel = GetDefaultSNBurstFluxModel();
       m_dsnb_fluxmodel = GetDefaultDSNBFluxModel();
@@ -146,6 +154,9 @@ class SKSNSimUserConfiguration{
     const static SKSNSIMENUM::TANKVOLUME GetDefaultEventVolume () { return SKSNSIMENUM::TANKVOLUME::kIDFULL; }
     const static SKSNSIMENUM::NEUTRINOOSCILLATION GetDefaultNeutrinoOscType () { return SKSNSIMENUM::NEUTRINOOSCILLATION::kNONE; }
     const static double GetDefaultSNDistanceKPC () { return 10. /* kpc */;}
+    const static double GetDefaultSNDirX() { return 0.; }  // Added for sndir argvar (patch)
+    const static double GetDefaultSNDirY() { return 0.; }  // Added for sndir argvar (patch)
+    const static double GetDefaultSNDirZ() { return -1.; }  // Added for sndir argvar (patch)
     const static std::string GetDefaultSNModelName () { return "nakazato/intp2002.data" ;}
     const static bool GetDefaultVectorGeneration () { return true; } 
     const static std::string GetDefaultOutputDirectory () { return "./vectout"; }
@@ -210,6 +221,14 @@ class SKSNSimUserConfiguration{
     SKSNSimUserConfiguration &SetRuntimeRunEnd(int r) { m_runtime_runend = r; return *this;}
     SKSNSimUserConfiguration &SetRuntimePeriod(int p) { m_runtime_period = p; return *this;}
     SKSNSimUserConfiguration &SetSNDistanceKpc(double d) { m_sndistance_kpc = d; return *this;}
+    
+    // Added for sndir (patch)
+    SKSNSimUserConfiguration &SetSNDir(double x, double y, double z) { 
+      m_sn_dir[0] = x; m_sn_dir[1] = y; m_sn_dir[2] = z; m_sn_dir_set = true; return *this;
+    }
+    const double* GetSNDir() const { return m_sn_dir; }
+    bool GetSNDirSet() const { return m_sn_dir_set; }
+
     SKSNSimUserConfiguration &SetSNBurstFluxModel(std::string f) { m_snburst_fluxmodel = f; return *this;}
     SKSNSimUserConfiguration &SetDSNBFluxModel(std::string f) { m_dsnb_fluxmodel = f; return *this;}
     SKSNSimUserConfiguration &SetDSNBFlatFlux(bool f) { m_dsnb_flatflux = f; return *this;}

--- a/include/SKSNSimVectorGenerator.hh
+++ b/include/SKSNSimVectorGenerator.hh
@@ -326,6 +326,7 @@ class SKSNSimVectorSNGenerator {
     int m_sn_time[3];
     double m_sn_dir[3];
     double m_distance_kpc;
+    bool m_sn_dir_set;  // added for sndir functionality (patch)
 
     // double m_max_hit_probability; // maximum of (flux) x (xsec) // should be updated with new flux or xsec models
 
@@ -385,6 +386,16 @@ class SKSNSimVectorSNGenerator {
     int SetRUNNUM(const int r){ m_runnum = r; return GetRUNNUM(); }
     int GetSubRUNNUM() const { return m_subrunnum; }
     int SetSubRUNNUM(const int r){ m_subrunnum = r; return GetSubRUNNUM(); }
+
+    // Added for sndir functionality (patch)
+    void SetSNDir(const double x, const double y, const double z) {
+      m_sn_dir[0] = x;
+      m_sn_dir[1] = y;
+      m_sn_dir[2] = z;
+      m_sn_dir_set = true;
+    }
+    const double* GetSNDir() const { return m_sn_dir; }
+    bool GetSNDirSet() const { return m_sn_dir_set; }
 };
 
 #endif

--- a/main_snburst.cc
+++ b/main_snburst.cc
@@ -1,5 +1,5 @@
 #include <memory>
-#include <TRandom3.h>
+#include "root/TRandom3.h"
 #include "SKSNSimTools.hh"
 #include "SKSNSimFileIO.hh"
 #include "SKSNSimVectorGenerator.hh"

--- a/src/SKSNSimCrosssection.cc
+++ b/src/SKSNSimCrosssection.cc
@@ -4,6 +4,11 @@
  * Cross section interface
  *************************************/
 
+// Bypass SKOFL Fortran routtines and use pure C++ calculations available to the container.
+#ifdef SKINTERNAL
+#undef SKINTERNAL
+#endif
+
 #include <cmath>
 #include <limits>
 #include <iostream>

--- a/src/SKSNSimFileIO.cc
+++ b/src/SKSNSimFileIO.cc
@@ -7,9 +7,9 @@
 #include <fstream>
 #include <sstream>
 #include <iomanip>
-#include <TFile.h>
+#include "root/TFile.h" // patch
 #include <TFileCacheWrite.h>
-#include <TTree.h>
+#include "root/TTree.h" //patch
 #include <TMath.h>
 #include "SKSNSimFileIO.hh"
 #include "skrun.h"

--- a/src/SKSNSimTools.cc
+++ b/src/SKSNSimTools.cc
@@ -1,3 +1,7 @@
+// Use pure C++ elapseday routine to bypass fortran (patch)
+#ifdef SKINTERNAL
+#undef SKINTERNAL
+#endif
 
 #include <iostream>
 #include <fstream>

--- a/src/SKSNSimUserConfiguration.cc
+++ b/src/SKSNSimUserConfiguration.cc
@@ -140,6 +140,7 @@ void SKSNSimUserConfiguration::ShowHelpSN(const char *argv0){
     << " [-m,--snmodel model_name]"
     << " [--nuosc 0(NONE)/1(NORMAL)/2(INVERTED)]"
     << " [-d,--distance distance_in_kpc]"
+    << " [--sndir x,y,z]"  // added for sndir (patch)
     << " [-g,--fillevent {0(no: just calculate expected num of evt)/1(yes: fill kinematics for detector sim.)}]"
     << " [--neventsperfile numberofevents]"
     << " [-s,--seed randomseed]"
@@ -155,7 +156,7 @@ void SKSNSimUserConfiguration::ShowHelpSN(const char *argv0){
     << " {outputdirectory}"
     << std::endl
     << std::endl;
-  std::cout << "Note: {} is essencial arguments, and [] is optional arguments" << std::endl << std::endl;
+  std::cout << "Note: {} is essential arguments, and [] is optional arguments" << std::endl << std::endl;  // patch, for clarity.
   std::cout << "Usage: for old argument format" << std::endl
     << argv0
     << " {model_name}"
@@ -171,6 +172,8 @@ void SKSNSimUserConfiguration::ShowHelpSN(const char *argv0){
     << " -m,--snmodel {model_name}: name of SN flux model (default = " << SKSNSimUserConfiguration::GetDefaultSNModelName() << " ) " << std::endl
     << " --nuosc {int}: neutrino oscillation model: 0=NONE / 1=NORMAL / 2=INVERTED ( default = " << (int)SKSNSimUserConfiguration::GetDefaultNeutrinoOscType() << " )" << std::endl
     << " -d,--distance {distance_in_kpc}: distance from SN in unit of kpc ( default = " << SKSNSimUserConfiguration::GetDefaultSNDistanceKPC() << " kpc)" << std::endl
+    << " --sndir {x,y,z}: SN direction in detector coordinates, comma-seperated unit vector"  // added for sndir (patch)
+       " (default = 0,0,-1 i.e., SN below detector)" << std::endl  // added for sndir (patch)
     << " -g,--fillevent [int]: if generate event kinematics for detector simulator: 0 = \"NO(just calculate expected num of evt) / 1 = YES (fill kinematics for detector sim.) (default = " << SKSNSimUserConfiguration::GetDefaultVectorGeneration() << " ). If you just specify \"-g\", turned ON" << std::endl
     << " --neventsperfile {numberofevents}: number of events in one file (default = " << SKSNSimUserConfiguration::GetDefaultNumEventsPerFile() << " )" << std::endl
     << " -s,--seed {randomseed}: random seed (default = " << SKSNSimUserConfiguration::GetDefaultRandomSeed() << " )" << std::endl
@@ -294,6 +297,7 @@ void SKSNSimUserConfiguration::LoadFromArgsSN(int argc, char *argv[]){
       {"runnum",        required_argument, 0,   0},
       {"subrunnum",     required_argument, 0,   0},
       {"outputformat",  required_argument, 0,   0}, // 17
+      {"sndir",         required_argument, 0,   0}, // index 18 --> Added for sndir (patch)
       {0,                               0, 0,   0}
     };
 
@@ -328,6 +332,12 @@ void SKSNSimUserConfiguration::LoadFromArgsSN(int argc, char *argv[]){
           case 15: SetRunnum(std::atoi(optarg)); break;
           case 16: SetSubRunnum(std::atoi(optarg)); break;
           case 17: SetOFileMode( std::string(optarg) ); break;
+          case 18: { // patch for sndir
+            double x=0., y=0., z=-1.;
+            sscanf(optarg, "%lf,%lf,%lf", &x, &y, &z);
+            SetSNDir(x,y,z);
+            break;
+          }
           default:
             ShowHelpSN(argv[0]);
             exit(EXIT_FAILURE);
@@ -395,6 +405,8 @@ void SKSNSimUserConfiguration::Dump() const {
   std::cout << "Runnum = " << GetRunnum() << std::endl;
   std::cout << "SubRunnum = " << GetSubRunnum() << std::endl;
   std::cout << "SNDistance ( kpc ) = " << GetSNDistanceKpc() << std::endl;
+  std::cout << "SNDir = " << GetSNDir()[0] << "," << GetSNDir()[1] << "," << GetSNDir()[2]   // added for sndir (patch)
+            << (m_sn_dir_set ? " (user-set)" : " (default)") << std::endl;  // added for sndir (patch)
   std::cout << "SNBurstFluxModel = " << GetSNBurstFluxModel() << std::endl;
   std::cout << "DSNBFluxModel = " << GetDSNBFluxModel() << std::endl;
   std::cout << "DSNBFlatFlux = " << GetDSNBFlatFlux() << std::endl;
@@ -414,6 +426,7 @@ void SKSNSimUserConfiguration::Apply( SKSNSimVectorSNGenerator &gen ) const {
   gen.SetFlagFillEvent( GetEventVectorGeneration() );
   gen.SetGeneratorVolume( GetEventgenVolume() );
   gen.SetSNDistanceKpc( GetSNDistanceKpc() );
+  if( GetSNDirSet() ) gen.SetSNDir( GetSNDir()[0], GetSNDir()[1], GetSNDir()[2]);  // added for sndir (patch)
   gen.SetGeneratorNuOscType( GetNuOscType() );
   gen.SetRUNNUM( GetRunnum() );
   gen.SetSubRUNNUM( GetSubRunnum() );

--- a/src/SKSNSimVectorGenerator.cc
+++ b/src/SKSNSimVectorGenerator.cc
@@ -3,13 +3,15 @@
  * *********************************/
 #include <functional>
 #include <algorithm>
-#include <TRandom3.h>
+#include "root/TRandom3.h" // patch
 #include "SKSNSimVectorGenerator.hh"
 #include "SKSNSimConstant.hh"
 #include "SKSNSimCrosssection.hh"
 #include "SKSNSimTools.hh"
 #include <typeinfo>
 #include <Math/Integrator.h> // For flux x xsec integration via ROOT
+
+#undef SKINTERNAL  // Bypass fortran implemtation of sn_sun_dir_ (patch)
 
 using namespace SKSNSimPhysConst;
 
@@ -383,6 +385,7 @@ SKSNSimVectorSNGenerator::SKSNSimVectorSNGenerator():
   m_sn_time[0] = 0;
   m_sn_time[1] = 0;
   m_sn_time[2] = 0;
+  m_sn_dir_set = false; // added for sndir functionality (patch)
 
   xsecmodels[XSECTYPE::mXSECIBD]       = std::make_unique<SKSNSimXSecIBDSV>();
   xsecmodels[XSECTYPE::mXSECELASTIC]   = std::make_unique<SKSNSimXSecNuElastic>();
@@ -436,20 +439,28 @@ std::vector<SKSNSimSNEventVector> SKSNSimVectorSNGenerator::GenerateEvents(){
   std::vector<double> OcrsNC[2][14]; // [rctn][ex_state] -> nu_energy -> total-xsec
 
 	/*-----determine SN direction-----*/
+  // patch for sndir functionality
   {
     float sdir[3], ra, dec;
-#ifdef SKITERNAL
-    sn_sundir_( m_sn_date, m_sn_time, sdir, & ra, & dec);
-#else
-    sdir[0] = 0.0;
-    sdir[1] = 0.0;
-    sdir[2] = -1.0;
-#endif
 
-    m_sn_dir[0] = sdir[0];
-    m_sn_dir[1] = sdir[1];
-    m_sn_dir[2] = sdir[2];
-  }
+    // Added for sndir functionality
+    if( m_sn_dir_set ) {
+      sdir[0] = (float)m_sn_dir[0];
+      sdir[1] = (float)m_sn_dir[1];
+      sdir[2] = (float)m_sn_dir[2];
+    } else {
+  #ifdef SKINTERNAL
+      sn_sundir_( m_sn_date, m_sn_time, sdir, & ra, & dec);
+  #else
+      sdir[0] = 0.0;
+      sdir[1] = 0.0;
+      sdir[2] = -1.0;
+  #endif
+    }
+      m_sn_dir[0] = sdir[0];
+      m_sn_dir[1] = sdir[1];
+      m_sn_dir[2] = sdir[2];
+    }
 
   const int flag_event = GetFlagFillEvent();
   const SKSNSimXSecNuElastic::FLAGETHR flag_elastic_thr = flag_event!=0? SKSNSimXSecNuElastic::ETHROFF : SKSNSimXSecNuElastic::ETHRON;
@@ -627,6 +638,11 @@ std::vector<SKSNSimSNEventVector> SKSNSimVectorSNGenerator::GenerateEvents(){
   double time;
   double nuEne;
   for(Int_t i_time =0; i_time < tNBins; i_time++) {
+
+    // Progress report for long calculation
+    if( tNBins > 0 && i_time % (tNBins/20 > 0 ? tNBins/20 : 1) == 0 )
+      std::cout << "Process loop progress: " << i_time << " / " << tNBins
+                << " (" << (100*i_time/tNBins) << "%)" << std::endl;
 
     time = tStart + (double(i_time)+0.5)*tBinSize; //center value of each bin[s]
     int itime_sn = int(time);
@@ -1120,6 +1136,10 @@ void SKSNSimVectorSNGenerator::FillEvent(std::vector<SKSNSimSNEventVector> &evt_
 
   std::cout << "start event loop in FillEvent" << std::endl; //nakanisi
   for( uint iEvt = 0; iEvt < evt_buffer.size(); iEvt++ ){
+
+    // Patch to provide progress information for long event generation
+    if( iEvt % 100 == 0 )
+      std::cout << "FillEvent progress: " << iEvt << " / " << evt_buffer.size() << std::endl;
 
     iSkip = 0;
 


### PR DESCRIPTION
## Purpose

Shared **for reference**: these are the modifications we made to build and run SKSNSim inside a container (no full SKOFL/ATMPD environment). **Not necessarily intended to merge as-is.**

Per-file patch notes are published in this branch for more detail (`container-support/doc/container-patches.md`).

## Container-related changes

- **GNUmakefile**: standalone build against a local ROOT v5.34.38 and SKOFL r32697 install; links `mcinfo`/`snevtinfo` directly with an rpath so the binary runs without a sourced SKOFL environment. `SKINTERNAL` is now always defined: without it, vector files leave the MCInfo and SNEvInfo branches empty, which breaks SKG4 compatibility. Paths like `/mnt/sim/deps/...` reflect our container image's internal layout.
- **ROOT include prefixes** (`"root/TFile.h"` etc.) in `main_snburst.cc`, `src/SKSNSimFileIO.cc`, `src/SKSNSimVectorGenerator.cc`, `example/reweight.cc`, matches the container's include layout.
- **Targeted `#undef SKINTERNAL`** in `SKSNSimCrosssection.cc`, `SKSNSimTools.cc`, `SKSNSimVectorGenerator.cc`, with `SKINTERNAL` globally on, these files opt back out to the pure-C++ fallbacks for the Fortran routines (`sn_sundir_`, elapseday) unavailable in the container.
- **download_data.sh**: extracts into the parent of `SKSNSIMDATADIR` so the tarball's directory structure lands where the code expects it.

## Possible upstream bug, independent of containers

`src/SKSNSimVectorGenerator.cc` had `#ifdef SKITERNAL` (typo for `SKINTERNAL`), which makes the `sn_sundir_` branch dead code even in standard SKOFL builds, the SN direction silently falls back to (0, 0, −1). This branch fixes the spelling.

## Also included (interleaved in the same files)

- A new `--sndir x,y,z` option to set the SN direction explicitly instead of deriving it from date/time via `sn_sundir_`.
- Progress printouts in `GenerateEvents`/`FillEvent` for long runs.

The patch-notes doc also mentions a `build_libsnevtinfo.sh` rebuild script. This lives in our SNBurstPiple repo, not in this PR.